### PR TITLE
fix: Some icons are not well displayed in meeds server - EXO-71197 - Meeds-io/MIPs#119

### DIFF
--- a/content-webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsFileDrop.vue
+++ b/content-webapp/src/main/webapp/news-activity-composer-app/components/ExoNewsFileDrop.vue
@@ -25,8 +25,11 @@
         :class="files.length >0 ? 'imageUploaded' : '' "
         class="dropMsg"
         for="uploadedFile">
-        <i class="uiIcon uiIconIllustrationUpload"></i>
-        <i class="uiIcon uiIconPlusCircled"></i>
+        <v-icon
+          size="50"
+          class="grey--text text--lighten-1">
+          fa-regular fa-image
+        </v-icon>
       </label>
       <input
         id="uploadedFile"

--- a/content-webapp/src/main/webapp/news/components/NewsAppItem.vue
+++ b/content-webapp/src/main/webapp/news/components/NewsAppItem.vue
@@ -60,7 +60,12 @@
             class="align-center width-full my-auto text-truncate flex-grow-0 flex"
             small-font-size
             popover />
-          <i v-if="!news.hiddenSpace" class="uiIconArrowNext pt-1"></i>
+          <v-icon
+            v-if="!news.hiddenSpace"
+            size="15"
+            class="text-color">
+            fas fa-chevron-right
+          </v-icon>
           <exo-space-avatar
             v-if="!news.hiddenSpace"
             :space-id="spaceId"


### PR DESCRIPTION
Prior to this change, ui icons used in some components are not displayed in meeds server due to an incompatibility issue related to the used icons font family with meeds. 
This PR replaces the old ui icons by fontawesome icons to resolve the issue.