### PR TITLE
fix: Define news article metadata item property 'deleted' - EXO-71614 - Meeds-io/MIPs#119

### DIFF
--- a/content-service/src/main/java/io/meeds/news/service/impl/NewsServiceImpl.java
+++ b/content-service/src/main/java/io/meeds/news/service/impl/NewsServiceImpl.java
@@ -140,6 +140,9 @@ public class NewsServiceImpl implements NewsService {
   /** The Constant AUDIENCE. */
   public static final String         NEWS_AUDIENCE                          = "audience";
 
+  /** The Constant DELETED. */
+  public static final String         NEWS_DELETED                           = "deleted";
+
   /** The Constant NEWS_ID. */
   public static final String         NEWS_ID                                = "newsId";
 
@@ -1556,6 +1559,7 @@ public class NewsServiceImpl implements NewsService {
         }
         newsPageProperties.put(NEWS_ACTIVITY_POSTED, String.valueOf(newsArticle.isActivityPosted()));
         newsPageProperties.put(PUBLISHED, String.valueOf(newsArticle.isPublished()));
+        newsPageProperties.put(NEWS_DELETED, String.valueOf(newsArticlePage.isDeleted()));
         metadataService.createMetadataItem(newsPageObject, NEWS_METADATA_KEY, newsPageProperties, Long.parseLong(newsArticleMetadataItemCreatorIdentityId));
 
         // delete the draft
@@ -1990,6 +1994,15 @@ public class NewsServiceImpl implements NewsService {
         if (news.getActivities() != null) {
           String newsActivities = news.getActivities();
           Stream.of(newsActivities.split(";")).map(activity -> activity.split(":")[1]).forEach(activityManager::deleteActivity);
+          NewsPageObject newsPageMetadataObject = new NewsPageObject(NEWS_METADATA_PAGE_OBJECT_TYPE, news.getId(), null, Long.parseLong(news.getSpaceId()));
+          MetadataItem metadataItem = metadataService.getMetadataItemsByMetadataAndObject(NEWS_METADATA_KEY, newsPageMetadataObject).stream().findFirst().orElse(null);
+          if (metadataItem != null) {
+            Map<String, String> properties = metadataItem.getProperties();
+            properties.put(NEWS_DELETED, String.valueOf(true));
+            metadataItem.setProperties(properties);
+            String currentIdentityId = identityManager.getOrCreateUserIdentity(currentIdentity.getUserId()).getId();
+            metadataService.updateMetadataItem(metadataItem, Long.parseLong(currentIdentityId));
+          }
         }
       }
     }

--- a/content-service/src/test/java/io/meeds/news/service/impl/NewsServiceImplTest.java
+++ b/content-service/src/test/java/io/meeds/news/service/impl/NewsServiceImplTest.java
@@ -788,20 +788,9 @@ public class NewsServiceImplTest {
     Map<String, String> properties = new HashMap<>();
     properties.put(NEWS_ACTIVITIES, "1:1;");
     when(metadataItem.getProperties()).thenReturn(properties);
-
-    Space space = mock(Space.class);
-    when(space.getId()).thenReturn("1");
-    when(space.getGroupId()).thenReturn("/space/groupId");
-    when(space.getAvatarUrl()).thenReturn("space/avatar/url");
-    when(space.getDisplayName()).thenReturn("spaceDisplayName");
-    when(space.getVisibility()).thenReturn("public");
-    when(spaceService.isSuperManager(anyString())).thenReturn(true);
-    when(spaceService.getSpaceById(any())).thenReturn(space);
-    when(spaceService.getSpaceByGroupId(anyString())).thenReturn(space);
-
-    Identity identity = mock(Identity.class);
-    when(identity.getUserId()).thenReturn("john");
-    NEWS_UTILS.when(() -> NewsUtils.getUserIdentity(anyString())).thenReturn(identity);
+    Space space = mockSpace();
+    Identity identity = mockIdentity();
+    when(identityManager.getOrCreateUserIdentity(anyString())).thenReturn(new org.exoplatform.social.core.identity.model.Identity("1"));
     NEWS_UTILS.when(() -> NewsUtils.canPublishNews(anyString(), any(Identity.class))).thenReturn(false);
     when(newsTargetingService.getTargetsByNews(any(News.class))).thenReturn(null);
 
@@ -829,6 +818,7 @@ public class NewsServiceImplTest {
     verify(noteService, times(1)).deleteNote(existingPage.getWikiType(), existingPage.getWikiOwner(), existingPage.getName());
     verify(noteService, times(1)).removeDraftById("1");
     verify(activityManager, times(1)).deleteActivity("1");
+    verify(metadataService, times(1)).updateMetadataItem(any(MetadataItem.class), anyLong());
   }
 
   @Test


### PR DESCRIPTION
Prior to this change, the 'deleted' property for news article metadata items was not defined during the news article creation process. This change will define the 'deleted' property for the news article metadata items during the creation process, and this property will also be updated when the news article is marked as deleted.