### PR TITLE
fix: Eslint error Failed to load plugin 'vue' declared in '.eslintrc.json' - EXO-71733 - Meeds-io/MIPs#130

### DIFF
--- a/content-webapp/package.json
+++ b/content-webapp/package.json
@@ -15,7 +15,7 @@
   "license": "LGPL",
   "devDependencies": {
     "babel-loader": "^8.3.0",
-    "eslint": "^8.12.0",
+    "eslint": "^8.42.0",
     "eslint-config-meedsio": "^1.0.5",
     "eslint-plugin-vue": "^8.6.0",
     "eslint-plugin-vuejs-accessibility": "^2.1.0",


### PR DESCRIPTION
 Eslint error Failed to load plugin 'vue' declared in '.eslintrc.json'