### PR TITLE
feat: fix scheduled news articles display in the published news filer - EXO-71735 - Meeds-io/MIPs#130

### DIFF
--- a/content-service/src/main/java/io/meeds/news/service/impl/NewsServiceImpl.java
+++ b/content-service/src/main/java/io/meeds/news/service/impl/NewsServiceImpl.java
@@ -1060,14 +1060,18 @@ public class NewsServiceImpl implements NewsService {
                                                 NEWS_AUDIENCE,
                                                 NewsUtils.SPACE_NEWS_AUDIENCE,
                                                 NEWS_DELETED,
-                                                "false"));
+                                                "false",
+                                                NEWS_PUBLICATION_STATE,
+                                                POSTED));
     metadataFilter.setMetadataSpaceIds(NewsUtils.getMyFilteredSpacesIds(currentIdentity, filter.getSpaces()));
     metadataFilter.setCombinedMetadataProperties(Map.of(PUBLISHED,
                                                         "true",
                                                         NEWS_AUDIENCE,
                                                         NewsUtils.ALL_NEWS_AUDIENCE,
                                                         NEWS_DELETED,
-                                                        "false"));
+                                                        "false",
+                                                        NEWS_PUBLICATION_STATE,
+                                                        POSTED));
     return metadataService.getMetadataItemsByFilter(metadataFilter, filter.getOffset(), filter.getLimit())
                           .stream()
                           .map(article -> {
@@ -1093,7 +1097,9 @@ public class NewsServiceImpl implements NewsService {
                                                         NEWS_AUDIENCE,
                                                         NewsUtils.ALL_NEWS_AUDIENCE,
                                                         NEWS_DELETED,
-                                                        "false"));
+                                                        "false",
+                                                        NEWS_PUBLICATION_STATE,
+                                                        POSTED));
     return metadataService.getMetadataItemsByFilter(metadataFilter, filter.getOffset(), filter.getLimit())
                           .stream()
                           .map(article -> {


### PR DESCRIPTION
Prior to this change this change , the scheduled news articles were displayed in the published news filter , this change is going to add the property publication state to the news filter resolving this issue .