### PR TITLE
fix: Remove edit mode from news portlet list - EXO-71286 - Meeds-io/MIPs#130

### DIFF
--- a/content-webapp/src/main/webapp/WEB-INF/portlet.xml
+++ b/content-webapp/src/main/webapp/WEB-INF/portlet.xml
@@ -107,7 +107,6 @@
     </init-param>
     <supports>
       <mime-type>text/html</mime-type>
-      <portlet-mode>edit</portlet-mode>
     </supports>
     <supported-locale>en</supported-locale>
     <portlet-info>


### PR DESCRIPTION
Remove edit mode from news portlet list