### PR TITLE
feat: Add extension property to add margin to the news activity content - MEED-6958 - Meeds-io/MIPs#124

### DIFF
--- a/content-webapp/src/main/webapp/news-extensions/activity-stream-extensions/extensions.js
+++ b/content-webapp/src/main/webapp/news-extensions/activity-stream-extensions/extensions.js
@@ -53,6 +53,7 @@ const newsActivityTypeExtensionOptions = {
   summaryLinesToDisplay: 3,
   noEmbeddedLinkView: true,
   windowTitlePrefixKey: 'news.window.title',
+  addMargin: true,
   getThumbnail: (activity) => activity?.news?.illustrationURL && `${activity?.news?.illustrationURL}&size=305x285` || '/content/images/news.png',
   getThumbnailProperties: (activity) => !(activity?.news?.illustrationURL) && {
     height: '90px',


### PR DESCRIPTION
This PR adds a new extension property to the news activity content extension, enabling the addition of extra top and bottom margins to the content