### PR TITLE
fix: Delete useless ResourceRequestFilter mappings - MEED-7004 - Meeds-io/meeds#2109

### DIFF
--- a/content-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/content-webapp/src/main/webapp/WEB-INF/web.xml
@@ -40,7 +40,10 @@
 
   <filter-mapping>
     <filter-name>ResourceRequestFilter</filter-name>
-    <url-pattern>/*</url-pattern>
+    <url-pattern>*.css</url-pattern>
+    <url-pattern>*.js</url-pattern>
+    <url-pattern>*.html</url-pattern>
+    <url-pattern>/images/*</url-pattern>
   </filter-mapping>
 
   <jsp-config>


### PR DESCRIPTION
Prior to this change, any URL was cached while the Cache HTTP Header should be applied systematically on static resources only. This change changes the Filter mapping list in order to include static resources only.

(Resolves Meeds-io/meeds#2109)