### PR TITLE
feat: Allow to distinguish Portlets ediable through layout - MEED-7033 - Meeds-io/meeds#2121

### DIFF
--- a/content-webapp/src/main/webapp/WEB-INF/portlet.xml
+++ b/content-webapp/src/main/webapp/WEB-INF/portlet.xml
@@ -105,6 +105,10 @@
       <name>preload.resource.bundles</name>
       <value>locale.portlet.news.News</value>
     </init-param>
+    <init-param>
+      <name>layout-content-editable</name>
+      <value>true</value>
+    </init-param>
     <supports>
       <mime-type>text/html</mime-type>
       <portlet-mode>view</portlet-mode>


### PR DESCRIPTION
This change will add a property to not mask CMS portlets while editing page.