### PR TITLE
fix: Space publisher is able to choose all space members as target audience - EXO-71975 - Meeds-io/meeds#2199.

### DIFF
--- a/content-webapp/src/main/webapp/components/targetSelector/ExoNewsTargetsSelector.vue
+++ b/content-webapp/src/main/webapp/components/targetSelector/ExoNewsTargetsSelector.vue
@@ -193,6 +193,9 @@ export default {
       }
     });
     this.selectedTargets = this.news.targets;
+    if (this.selectedTargets.length > 0) {
+      this.selectAudience(this.selectedTargets);
+    }
     this.$nextTick(() => this.isDataInitialized = true);
   },
   watch: {


### PR DESCRIPTION
Before this change, when publish an article, as user is publisher in spacex, in newsTarget audience is preselected (only space members) and click on publish from menu action of the article, audience dropdown is enabled and publisher can choose all users. After this change, audience limitation is maintained.