### PR TITLE
fix: Display default lang title when no translations available in news list header settings - EXO-72574 - Meeds-io/MIPs#128

### DIFF
--- a/content-webapp/src/main/webapp/news-list-view/components/settings/NewsSettingsDrawer.vue
+++ b/content-webapp/src/main/webapp/news-list-view/components/settings/NewsSettingsDrawer.vue
@@ -85,7 +85,6 @@
               ref="headerNameInput"
               id="headerNameInput"
               v-model="newsHeader"
-              :default-language="defaultLanguage"
               :placeholder="$t('news.list.settings.placeHolderName')"
               drawer-title="news.list.settings.translation.header"
               maxlength="100"
@@ -227,8 +226,7 @@ export default {
     saveSettingsURL: '',
     canManageNewsPublishTargets: eXo.env.portal.canManageNewsPublishTargets,
     translationObjectType: 'newsListView',
-    defaultLanguage: 'en',
-    headerTitleFieldName: 'headerNameInput'
+    headerTitleFieldName: 'headerNameInput',
   }),
   props: {
     language: {
@@ -348,8 +346,8 @@ export default {
       this.viewTemplate = this.$root.viewTemplate;
       this.viewExtensions = this.$root.viewExtensions;
       this.newsTarget = this.$root.newsTarget;
-      this.newsHeader = (this.newListTranslationEnabled && (this.savedHeaderTranslations
-                                                       || {[this.defaultLanguage]: this.$root.headerTitle}))
+      this.newsHeader = (this.newListTranslationEnabled && (this.savedHeaderTranslations?.length && this.savedHeaderTranslations
+                                                       || {[this.$root.defaultLanguage]: this.$root.headerTitle}))
                                                        || this.$root.headerTitle;
       this.limit = this.$root.limit;
       this.showHeader = this.viewTemplate === 'NewsSlider' || this.viewTemplate === 'NewsMosaic' || this.viewTemplate === 'NewsStories' ? false : this.$root.showHeader;

--- a/content-webapp/src/main/webapp/news-list-view/main.js
+++ b/content-webapp/src/main/webapp/news-list-view/main.js
@@ -97,7 +97,8 @@ export function init(params) {
         showArticleSpace,
         showArticleReactions,
         showArticleDate,
-        seeAllUrl
+        seeAllUrl,
+        defaultLanguage: eXo?.env?.portal?.defaultLanguage
       },
       computed: {
         newListTranslationEnabled() {
@@ -111,7 +112,7 @@ export function init(params) {
         }
         Vue.prototype.$translationService.getTranslations('newsListView', applicationId, 'headerNameInput').then(translations => {
           this.headerTranslations = translations;
-          this.headerTitle = translations?.[lang] || translations?.en
+          this.headerTitle = translations?.[lang] || translations?.[this.defaultLanguage]
                                                   || params.headerTitle;
         });
       },


### PR DESCRIPTION
Fix display default lang title when no translations available in news list header settings