### PR TITLE
feat: Redefine Parent applications Classes to fit layout style properties - MEED-7094 - Meeds-io/MIPs#144

### DIFF
--- a/content-webapp/src/main/webapp/WEB-INF/jsp/newsListView.jsp
+++ b/content-webapp/src/main/webapp/WEB-INF/jsp/newsListView.jsp
@@ -1,23 +1,3 @@
-<!--
-
-	This file is part of the Meeds project (https://meeds.io/).
-
-  Copyright (C) 2020 - 2024 Meeds Association contact@meeds.io
-	This program is free software; you can redistribute it and/or
-	modify it under the terms of the GNU Lesser General Public
-	License as published by the Free Software Foundation; either
-	version 3 of the License, or (at your option) any later version.
-
-  This program is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-	Lesser General Public License for more details.
-
-  You should have received a copy of the GNU Lesser General Public License
-	along with this program; if not, write to the Free Software Foundation,
-	Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-
--->
 <%@page import="org.exoplatform.container.ExoContainerContext"%>
 <%@page import="org.exoplatform.services.security.ConversationState"%>
 <%@page import="org.exoplatform.services.security.Identity"%>

--- a/content-webapp/src/main/webapp/WEB-INF/portlet.xml
+++ b/content-webapp/src/main/webapp/WEB-INF/portlet.xml
@@ -36,6 +36,10 @@
       <name>preload.resource.bundles</name>
       <value>locale.portlet.news.News</value>
     </init-param>
+    <init-param>
+      <name>layout-css-class</name>
+      <value>no-layout-style</value>
+    </init-param>
     <supports>
       <mime-type>text/html</mime-type>
     </supports>

--- a/content-webapp/src/main/webapp/latest-news/components/ExoLatestNews.vue
+++ b/content-webapp/src/main/webapp/latest-news/components/ExoLatestNews.vue
@@ -22,11 +22,10 @@
   <v-app
     class="VuetifyApp"
     flat>
-    <v-container pa-0>
+    <v-container class="application-body" pa-0>
       <v-layout
         row
-        mx-0
-        class="card-border-radius app-background-color">
+        mx-0>
         <v-flex class="px-3 border-box-sizing">
           <v-layout class="d-flex mx-0 align-center border-box-sizing">
             <v-flex class="d-flex text-truncate">

--- a/content-webapp/src/main/webapp/news-activity-composer-app/index.jsp
+++ b/content-webapp/src/main/webapp/news-activity-composer-app/index.jsp
@@ -1,23 +1,3 @@
-<!--
-
-    This file is part of the Meeds project (https://meeds.io/).
-
-  Copyright (C) 2020 - 2024 Meeds Association contact@meeds.io
-    This program is free software; you can redistribute it and/or
-    modify it under the terms of the GNU Lesser General Public
-    License as published by the Free Software Foundation; either
-    version 3 of the License, or (at your option) any later version.
-
-  This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-  You should have received a copy of the GNU Lesser General Public License
-    along with this program; if not, write to the Free Software Foundation,
-    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-
--->
 <div class="VuetifyApp">
   <div id="NewsComposerApp">
   </div>

--- a/content-webapp/src/main/webapp/news-details-app/index.jsp
+++ b/content-webapp/src/main/webapp/news-details-app/index.jsp
@@ -1,24 +1,3 @@
-<!--
-
-    This file is part of the Meeds project (https://meeds.io/).
-
-  Copyright (C) 2020 - 2024 Meeds Association contact@meeds.io
-    This program is free software; you can redistribute it and/or
-    modify it under the terms of the GNU Lesser General Public
-    License as published by the Free Software Foundation; either
-    version 3 of the License, or (at your option) any later version.
-
-  This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-  You should have received a copy of the GNU Lesser General Public License
-    along with this program; if not, write to the Free Software Foundation,
-    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-
--->
-
 <div class="VuetifyApp">
   <div id="NewsDetailApp">
   </div>

--- a/content-webapp/src/main/webapp/news-list-view/components/NewsListView.vue
+++ b/content-webapp/src/main/webapp/news-list-view/components/NewsListView.vue
@@ -23,7 +23,7 @@
     <v-app v-show="!hideEmptyNewsTemplateForNonPublisher" class="news-list-view-app position-relative">
       <v-card
         :class="newsListViewClass"
-        class="app-background-color"
+        class="application-body"
         height="100%"
         flat>
         <v-card-text class="pa-0">

--- a/content-webapp/src/main/webapp/news-list-view/components/views/NewsEmptyTemplate.vue
+++ b/content-webapp/src/main/webapp/news-list-view/components/views/NewsEmptyTemplate.vue
@@ -21,7 +21,7 @@
 <template>
   <v-hover v-slot="{ hover }">
     <v-app v-show="canPublishNews" class="newsEmptyTemplate border-box-sizing" flat>
-      <v-main class="white">
+      <v-main>
         <v-sheet height="32" class="news-empty-header d-flex mx-3 my-2">
           <v-spacer />
           <div class="d-flex flex-row newsSettingButton justify-end">

--- a/content-webapp/src/main/webapp/news-publish-targets-management/components/NewsPublishTargetsManagement.vue
+++ b/content-webapp/src/main/webapp/news-publish-targets-management/components/NewsPublishTargetsManagement.vue
@@ -20,8 +20,8 @@
 -->
 <template>
   <v-app class="newsTargetsAdminSettings">
-    <v-main class="card-border-radius app-background-color pa-5">
-      <div class="app-background-color">
+    <v-main class="application-body pa-5">
+      <div>
         <div class="d-flex flex-row">
           <h4 class="pb-5 font-weight-bold">
             {{ $t('newsTargets.settings.title') }}

--- a/content-webapp/src/main/webapp/news-publish-targets-management/newsPublishTargetsManagement.html
+++ b/content-webapp/src/main/webapp/news-publish-targets-management/newsPublishTargetsManagement.html
@@ -1,23 +1,3 @@
-<!--
-
-    This file is part of the Meeds project (https://meeds.io/).
-
-  Copyright (C) 2020 - 2024 Meeds Association contact@meeds.io
-    This program is free software; you can redistribute it and/or
-    modify it under the terms of the GNU Lesser General Public
-    License as published by the Free Software Foundation; either
-    version 3 of the License, or (at your option) any later version.
-
-  This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-  You should have received a copy of the GNU Lesser General Public License
-    along with this program; if not, write to the Free Software Foundation,
-    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-
--->
 <div class="VuetifyApp">
     <div data-app="true"
          class="v-application v-application--is-ltr theme--light"

--- a/content-webapp/src/main/webapp/news/components/NewsApp.vue
+++ b/content-webapp/src/main/webapp/news/components/NewsApp.vue
@@ -20,7 +20,7 @@
 -->
 <template>
   <v-app class="newsApp" role="main">
-    <div class="card-border-radius app-background-color pa-5">
+    <div class="application-body pa-5">
       <v-toolbar
         color="transparent"
         flat
@@ -72,15 +72,14 @@
         <news-filter-space-drawer
           v-model="spacesFilter" />
       </div>
-      <v-app
-        class="VuetifyApp">
+      <div>
         <v-progress-circular
           v-if="loadingNews && newsList.length === 0"
           :size="40"
           :width="4"
           indeterminate
           class="loadingRing" />
-      </v-app>
+      </div>
       <div
         v-if="newsList.length"
         id="newsListItems"

--- a/content-webapp/src/main/webapp/news/news.html
+++ b/content-webapp/src/main/webapp/news/news.html
@@ -1,24 +1,3 @@
-<!--
-
-    This file is part of the Meeds project (https://meeds.io/).
-
-  Copyright (C) 2020 - 2024 Meeds Association contact@meeds.io
-    This program is free software; you can redistribute it and/or
-    modify it under the terms of the GNU Lesser General Public
-    License as published by the Free Software Foundation; either
-    version 3 of the License, or (at your option) any later version.
-
-  This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-  You should have received a copy of the GNU Lesser General Public License
-    along with this program; if not, write to the Free Software Foundation,
-    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-
--->
-
 <div class="VuetifyApp">
   <div id="NewsApp" class="newsApp">
     <script>


### PR DESCRIPTION
This change will apply **application-body** class to the main body of applications to make sure to apply layout specific CSS styles, such as disabling default Vuetify White Background applied on v-card. At the same time, for Top Toolbar applications, this will disable branding styling to avoid having border radius and other styles applied on small buttons added in Top bar as applications.