### PR TITLE
fix: NewsList view setting header translations are lost when edit page layout - EXO-72574 - Meeds-io/MIPs#128

### DIFF
--- a/content-webapp/pom.xml
+++ b/content-webapp/pom.xml
@@ -60,6 +60,11 @@
       <classifier>sources</classifier>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.exoplatform.social</groupId>
+      <artifactId>social-component-web</artifactId>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/content-webapp/src/main/java/io/meeds/news/portlet/NewsListViewPortlet.java
+++ b/content-webapp/src/main/java/io/meeds/news/portlet/NewsListViewPortlet.java
@@ -21,17 +21,25 @@ package io.meeds.news.portlet;
 
 import java.io.IOException;
 import java.util.Enumeration;
+import java.util.Random;
 
-import javax.portlet.ActionRequest;
-import javax.portlet.ActionResponse;
-import javax.portlet.PortletException;
-import javax.portlet.PortletPreferences;
 
+import javax.portlet.*;
+
+import io.meeds.social.portlet.CMSPortlet;
 import org.apache.commons.lang3.StringUtils;
 
-import org.exoplatform.commons.api.portlet.GenericDispatchedViewPortlet;
+public class NewsListViewPortlet extends CMSPortlet {
 
-public class NewsListViewPortlet extends GenericDispatchedViewPortlet {
+  private static final String OBJECT_TYPE    = "newsListViewPortlet";
+
+  private static final String APPLICATION_ID = "applicationId";
+
+  @Override
+  public void init(PortletConfig config) throws PortletException {
+    super.init(config);
+    this.contentType = OBJECT_TYPE;
+  }
 
   @Override
   public void processAction(ActionRequest request, ActionResponse response) throws PortletException, IOException {
@@ -46,5 +54,21 @@ public class NewsListViewPortlet extends GenericDispatchedViewPortlet {
       preferences.setValue(name, value);
     }
     preferences.store();
+  }
+
+  @Override
+  public void doView(RenderRequest request, RenderResponse response) throws PortletException, IOException {
+    request.setAttribute(APPLICATION_ID, getOrCreateApplicationId(request.getPreferences()));
+    super.doView(request, response);
+  }
+
+  private String getOrCreateApplicationId(PortletPreferences preferences) {
+    String applicationId = preferences.getValue(APPLICATION_ID, null);
+    if (applicationId == null) {
+      Random random = new Random();
+      applicationId = String.valueOf(Math.abs(random.nextLong()));
+      savePreference(APPLICATION_ID, applicationId);
+    }
+    return applicationId;
   }
 }

--- a/content-webapp/src/main/java/io/meeds/news/portlet/NewsListViewPortlet.java
+++ b/content-webapp/src/main/java/io/meeds/news/portlet/NewsListViewPortlet.java
@@ -23,11 +23,17 @@ import java.io.IOException;
 import java.util.Enumeration;
 import java.util.Random;
 
+import javax.portlet.ActionRequest;
+import javax.portlet.ActionResponse;
+import javax.portlet.PortletConfig;
+import javax.portlet.PortletException;
+import javax.portlet.PortletPreferences;
+import javax.portlet.RenderRequest;
+import javax.portlet.RenderResponse;
 
-import javax.portlet.*;
+import org.apache.commons.lang3.StringUtils;
 
 import io.meeds.social.portlet.CMSPortlet;
-import org.apache.commons.lang3.StringUtils;
 
 public class NewsListViewPortlet extends CMSPortlet {
 

--- a/content-webapp/src/main/webapp/WEB-INF/jsp/newsListView.jsp
+++ b/content-webapp/src/main/webapp/WEB-INF/jsp/newsListView.jsp
@@ -23,7 +23,6 @@
 <%@ page import="io.meeds.news.utils.NewsUtils" %>
 <%@ page import="org.exoplatform.web.PortalHttpServletResponseWrapper" %>
 <%@ page import="org.exoplatform.portal.application.PortalRequestContext" %>
-<%@ page import="org.exoplatform.portal.webui.application.UIPortlet" %>
 <%@ page import="org.exoplatform.commons.api.settings.ExoFeatureService" %>
 <%@ page import="org.exoplatform.commons.utils.CommonsUtils" %>
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
@@ -33,7 +32,8 @@
 
 <div id="newsListViewApp" class="VuetifyApp">
   <%
-    String applicationId = UIPortlet.getCurrentUIPortlet().getStorageId();
+    String[] applicationIdParam = (String[]) request.getAttribute("applicationId");
+    String applicationId = applicationIdParam[0];
     int generatedId = (int) (Math.random() * 1000000l);
     String appId = "news-list-view-" + generatedId;
     String[] viewTemplateParams = (String[]) request.getAttribute("viewTemplate");

--- a/content-webapp/src/main/webapp/news-list-view/components/settings/NewsSettingsDrawer.vue
+++ b/content-webapp/src/main/webapp/news-list-view/components/settings/NewsSettingsDrawer.vue
@@ -343,7 +343,7 @@ export default {
       this.viewTemplate = this.$root.viewTemplate;
       this.viewExtensions = this.$root.viewExtensions;
       this.newsTarget = this.$root.newsTarget;
-      this.newsHeader = (this.newListTranslationEnabled && (Object.keys(this.savedHeaderTranslations)?.length && this.savedHeaderTranslations
+      this.newsHeader = (this.newListTranslationEnabled && (Object.keys(this.savedHeaderTranslations || {})?.length && this.savedHeaderTranslations
                                                        || {[this.$root.defaultLanguage]: this.$root.headerTitle}))
                                                        || this.$root.headerTitle;
       this.limit = this.$root.limit;


### PR DESCRIPTION

NewsList view setting header translations are lost when edit page layout