### PR TITLE
feat: keep the news list view settings after switching from the advanced setting drawer - EXO-72652 - Meeds-io/MIPs#128

### DIFF
--- a/content-webapp/src/main/webapp/news-list-view/components/settings/NewsSettingsDrawer.vue
+++ b/content-webapp/src/main/webapp/news-list-view/components/settings/NewsSettingsDrawer.vue
@@ -157,7 +157,7 @@
           </div>
         </div>
         <news-advanced-settings
-          v-else
+          v-show="showAdvancedSettings"
           :show-article-summary="showArticleSummary"
           :show-see-all="showSeeAll"
           :show-header="showHeader"


### PR DESCRIPTION
Prior to this change, the child component newsAdvancedSettings initialized on every click of the showAdvancedSettings, causing the user modifications to be lost. After this change, using v-show, it will be initialized only once with the parent component.