### PR TITLE
fix: Search news by title or summary is not working - EXO-72721

### DIFF
--- a/content-service/src/main/java/io/meeds/news/search/NewsSearchConnector.java
+++ b/content-service/src/main/java/io/meeds/news/search/NewsSearchConnector.java
@@ -64,7 +64,7 @@ public class NewsSearchConnector {
 
   public static final String           SEARCH_QUERY_TERM            = """
                                                                       "must":{ "query_string" :{
-                                                                              "fields": ["body", "posterName"],
+                                                                              "fields": ["body", "posterName", "summary","title"],
                                                                               "default_operator": "AND",
                                                                               "query": "@term@"}
                                                                               },""";


### PR DESCRIPTION
Before this fix, when searching a new with a term in the title or in the summary was not working This is because the ES search query search only in body and posterName This commit add the search in summary and title

Resolves meeds-io/meeds#2233