### PR TITLE
fix: Display default lang title when no translations available in news list header settings - EXO-72574 - Meeds-io/MIPs#128

### DIFF
--- a/content-webapp/pom.xml
+++ b/content-webapp/pom.xml
@@ -60,6 +60,11 @@
       <classifier>sources</classifier>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.exoplatform.social</groupId>
+      <artifactId>social-component-web</artifactId>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/content-webapp/src/main/java/io/meeds/news/portlet/NewsListViewPortlet.java
+++ b/content-webapp/src/main/java/io/meeds/news/portlet/NewsListViewPortlet.java
@@ -21,17 +21,31 @@ package io.meeds.news.portlet;
 
 import java.io.IOException;
 import java.util.Enumeration;
+import java.util.Random;
 
 import javax.portlet.ActionRequest;
 import javax.portlet.ActionResponse;
+import javax.portlet.PortletConfig;
 import javax.portlet.PortletException;
 import javax.portlet.PortletPreferences;
+import javax.portlet.RenderRequest;
+import javax.portlet.RenderResponse;
 
 import org.apache.commons.lang3.StringUtils;
 
-import org.exoplatform.commons.api.portlet.GenericDispatchedViewPortlet;
+import io.meeds.social.portlet.CMSPortlet;
 
-public class NewsListViewPortlet extends GenericDispatchedViewPortlet {
+public class NewsListViewPortlet extends CMSPortlet {
+
+  private static final String OBJECT_TYPE    = "newsListViewPortlet";
+
+  private static final String APPLICATION_ID = "applicationId";
+
+  @Override
+  public void init(PortletConfig config) throws PortletException {
+    super.init(config);
+    this.contentType = OBJECT_TYPE;
+  }
 
   @Override
   public void processAction(ActionRequest request, ActionResponse response) throws PortletException, IOException {
@@ -46,5 +60,21 @@ public class NewsListViewPortlet extends GenericDispatchedViewPortlet {
       preferences.setValue(name, value);
     }
     preferences.store();
+  }
+
+  @Override
+  public void doView(RenderRequest request, RenderResponse response) throws PortletException, IOException {
+    request.setAttribute(APPLICATION_ID, getOrCreateApplicationId(request.getPreferences()));
+    super.doView(request, response);
+  }
+
+  private String getOrCreateApplicationId(PortletPreferences preferences) {
+    String applicationId = preferences.getValue(APPLICATION_ID, null);
+    if (applicationId == null) {
+      Random random = new Random();
+      applicationId = String.valueOf(Math.abs(random.nextLong()));
+      savePreference(APPLICATION_ID, applicationId);
+    }
+    return applicationId;
   }
 }

--- a/content-webapp/src/main/webapp/WEB-INF/jsp/newsListView.jsp
+++ b/content-webapp/src/main/webapp/WEB-INF/jsp/newsListView.jsp
@@ -23,7 +23,6 @@
 <%@ page import="io.meeds.news.utils.NewsUtils" %>
 <%@ page import="org.exoplatform.web.PortalHttpServletResponseWrapper" %>
 <%@ page import="org.exoplatform.portal.application.PortalRequestContext" %>
-<%@ page import="org.exoplatform.portal.webui.application.UIPortlet" %>
 <%@ page import="org.exoplatform.commons.api.settings.ExoFeatureService" %>
 <%@ page import="org.exoplatform.commons.utils.CommonsUtils" %>
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
@@ -33,7 +32,13 @@
 
 <div id="newsListViewApp" class="VuetifyApp">
   <%
-    String applicationId = UIPortlet.getCurrentUIPortlet().getStorageId();
+    String applicationId;
+    Object applicationIdParam = request.getAttribute("applicationId");
+    if (applicationIdParam instanceof String[]) {
+      applicationId = ((String[]) applicationIdParam)[0];
+    } else {
+      applicationId = (String) applicationIdParam;
+    }
     int generatedId = (int) (Math.random() * 1000000l);
     String appId = "news-list-view-" + generatedId;
     String[] viewTemplateParams = (String[]) request.getAttribute("viewTemplate");

--- a/content-webapp/src/main/webapp/news-list-view/components/settings/NewsSettingsDrawer.vue
+++ b/content-webapp/src/main/webapp/news-list-view/components/settings/NewsSettingsDrawer.vue
@@ -85,7 +85,6 @@
               ref="headerNameInput"
               id="headerNameInput"
               v-model="newsHeader"
-              :default-language="defaultLanguage"
               :placeholder="$t('news.list.settings.placeHolderName')"
               drawer-title="news.list.settings.translation.header"
               maxlength="100"
@@ -227,8 +226,7 @@ export default {
     saveSettingsURL: '',
     canManageNewsPublishTargets: eXo.env.portal.canManageNewsPublishTargets,
     translationObjectType: 'newsListView',
-    defaultLanguage: 'en',
-    headerTitleFieldName: 'headerNameInput'
+    headerTitleFieldName: 'headerNameInput',
   }),
   props: {
     language: {
@@ -263,11 +261,8 @@ export default {
     displayedViewTemplates() {
       return this.viewTemplates.filter(e=> !e.name.includes('EmptyTemplate'));
     },
-    hasNewsHeader() {
-      return this.newListTranslationEnabled && this.newsHeader?.[this.language]?.length || this.newsHeader?.length;
-    },
     disabled() {
-      return !this.hasNewsHeader || (this.showSeeAll && !this.isValidSeeAllUrl);
+      return this.showSeeAll && !this.isValidSeeAllUrl;
     },
     previewTemplate() {
       if ( this.viewTemplate === 'NewsLatest') {
@@ -348,8 +343,8 @@ export default {
       this.viewTemplate = this.$root.viewTemplate;
       this.viewExtensions = this.$root.viewExtensions;
       this.newsTarget = this.$root.newsTarget;
-      this.newsHeader = (this.newListTranslationEnabled && (this.savedHeaderTranslations
-                                                       || {[this.defaultLanguage]: this.$root.headerTitle}))
+      this.newsHeader = (this.newListTranslationEnabled && (Object.keys(this.savedHeaderTranslations || {})?.length && this.savedHeaderTranslations
+                                                       || {[this.$root.defaultLanguage]: this.$root.headerTitle}))
                                                        || this.$root.headerTitle;
       this.limit = this.$root.limit;
       this.showHeader = this.viewTemplate === 'NewsSlider' || this.viewTemplate === 'NewsMosaic' || this.viewTemplate === 'NewsStories' ? false : this.$root.showHeader;
@@ -406,8 +401,8 @@ export default {
           this.$root.viewTemplate = this.viewTemplate;
           this.$root.newsTarget = this.newsTarget;
           this.$root.headerTranslations = this.newsHeader;
-          this.$root.headerTitle = this.newListTranslationEnabled && this.newsHeader?.[this.language]
-                                                                  || this.newsHeader;
+          this.$root.headerTitle = this.newListTranslationEnabled ? this.newsHeader?.[this.language]
+              || this.newsHeader?.[this.$root.defaultLanguage] : this.newsHeader;
           this.$root.limit = this.limit;
           this.$root.showHeader = this.showHeader;
           this.$root.showSeeAll = this.showSeeAll;
@@ -423,8 +418,8 @@ export default {
             limit: this.limit,
             showHeader: this.showHeader,
             headerTranslations: this.newsHeader,
-            headerTitle: this.newListTranslationEnabled && this.newsHeader?.[this.language]
-                                                        || this.newsHeader,
+            headerTitle: this.newListTranslationEnabled ? this.newsHeader?.[this.language]
+                || this.newsHeader?.[this.$root.defaultLanguage] : this.newsHeader,
             showSeeAll: this.showSeeAll,
             showArticleTitle: this.showArticleTitle,
             showArticleSummary: this.showArticleSummary,

--- a/content-webapp/src/main/webapp/news-list-view/main.js
+++ b/content-webapp/src/main/webapp/news-list-view/main.js
@@ -97,7 +97,8 @@ export function init(params) {
         showArticleSpace,
         showArticleReactions,
         showArticleDate,
-        seeAllUrl
+        seeAllUrl,
+        defaultLanguage: eXo?.env?.portal?.defaultLanguage
       },
       computed: {
         newListTranslationEnabled() {
@@ -111,7 +112,7 @@ export function init(params) {
         }
         Vue.prototype.$translationService.getTranslations('newsListView', applicationId, 'headerNameInput').then(translations => {
           this.headerTranslations = translations;
-          this.headerTitle = translations?.[lang] || translations?.en
+          this.headerTitle = translations?.[lang] || translations?.[this.defaultLanguage]
                                                   || params.headerTitle;
         });
       },


### PR DESCRIPTION

Fix display default lang title when no translations available in news list header settings
fix: available new list settings header translations are not displayed 
Make latest news list portlet setting header non mandatory 
fix: NewsList view setting header translations are lost when edit page layout
