### PR TITLE
imporvement: keep original settings icon color when see all card is displayed - EXO-70399 - Meeds-io/meeds#2296

### DIFF
--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsStoriesView.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsStoriesView.vue
@@ -33,7 +33,6 @@
           class="card">
           <news-settings 
             :hide-see-all-button="true"
-            class-button-open-settings="settingNewsButton"
             :is-hovering="hover" />
           <a
             class="see-all-link"


### PR DESCRIPTION
This imporvement will allow to keep original settings icon color when see all card is displayed, when this option is enabled, in news Stories template in order to differentiate it from the card's white color.