### PR TITLE
fix: Broken illustration displayed after deleting the featured image - EXO-73514 - Meeds-io/MIPs#128

### DIFF
--- a/content-service/src/main/java/io/meeds/news/utils/NewsUtils.java
+++ b/content-service/src/main/java/io/meeds/news/utils/NewsUtils.java
@@ -271,7 +271,8 @@ public class NewsUtils {
   }
 
   public static String buildIllustrationUrl(NotePageProperties properties, String lang) {
-    if (properties == null || properties.getFeaturedImage() == null) {
+    if (properties == null || properties.getFeaturedImage() == null || properties.getFeaturedImage().getId() == null
+        || properties.getFeaturedImage().getId() == 0L) {
       return null;
     }
     NoteFeaturedImage featuredImage = properties.getFeaturedImage();


### PR DESCRIPTION
Broken illustration displayed after deleting the featured image