### PR TITLE
feat: Fix NewsIndexingServiceConnector initialization - EXO-73544 - Meeds-io/MIPs#128

### DIFF
--- a/content-service/src/main/java/io/meeds/news/search/NewsIndexingServiceConnector.java
+++ b/content-service/src/main/java/io/meeds/news/search/NewsIndexingServiceConnector.java
@@ -24,17 +24,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import org.exoplatform.commons.search.domain.Document;
-import org.exoplatform.commons.search.index.IndexingOperationProcessor;
 import org.exoplatform.commons.search.index.impl.ElasticIndexingServiceConnector;
 import org.exoplatform.commons.utils.HTMLSanitizer;
 import org.exoplatform.container.xml.InitParams;
-import org.exoplatform.container.xml.PropertiesParam;
-import org.exoplatform.container.xml.ValueParam;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.social.core.activity.model.ActivityStream;
@@ -51,53 +47,31 @@ import org.exoplatform.social.metadata.model.MetadataObject;
 import io.meeds.news.model.News;
 import io.meeds.news.service.NewsService;
 import io.meeds.news.utils.NewsUtils;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
 
-import javax.annotation.PostConstruct;
-
-@Component
 public class NewsIndexingServiceConnector extends ElasticIndexingServiceConnector {
 
-  public static final String         TYPE                        = "news";
+  public static final String    TYPE = "news";
 
-  private static final Log           LOG                         = ExoLogger.getLogger(NewsIndexingServiceConnector.class);
+  private static final Log      LOG  = ExoLogger.getLogger(NewsIndexingServiceConnector.class);
 
-  private static final String        INDEX_ALIAS_PROPERTY_NAME   = "index_alias";
+  private final NewsService     newsService;
 
-  private static final String        INDEX_CURRENT_PROPERTY_NAME = "index_current";
+  private final IdentityManager identityManager;
 
-  private static final String        FILE_PATH_PROPERTY_NAME     = "mapping.file.path";
+  private final ActivityManager activityManager;
 
-  private static final String        INDEX_ALIAS_VALUE           = "news_alias";
+  private final MetadataService metadataService;
 
-  private static final String        INDEX_CURRENT_VALUE         = "news_v1";
-  
-  private static final String        SUMMARY_PROPERTY            = "summary";
-
-  @Autowired
-  private NewsService                newsService;
-
-  @Autowired
-  private IdentityManager            identityManager;
-
-  @Autowired
-  private ActivityManager            activityManager;
-
-  @Autowired
-  private MetadataService            metadataService;
-
-  @Autowired
-  private IndexingOperationProcessor indexingOperationProcessor;
-
-  public NewsIndexingServiceConnector(@Value("${content.es.mapping.path:jar:/news-es-mapping.json}") String mappingFilePath) {
-    super(getInitParams(mappingFilePath));
-  }
-
-  @PostConstruct
-  public void init() {
-    indexingOperationProcessor.addConnector(this);
+  public NewsIndexingServiceConnector(IdentityManager identityManager,
+                                      InitParams initParams,
+                                      NewsService newsService,
+                                      ActivityManager activityManager,
+                                      MetadataService metadataService) {
+    super(initParams);
+    this.newsService = newsService;
+    this.identityManager = identityManager;
+    this.activityManager = activityManager;
+    this.metadataService = metadataService;
   }
 
   @Override
@@ -167,7 +141,7 @@ public class NewsIndexingServiceConnector extends ElasticIndexingServiceConnecto
         LOG.warn("Error sanitizing news '{}' summary", news.getId());
       }
       summary = htmlToText(summary);
-      fields.put(SUMMARY_PROPERTY, summary);
+      fields.put("summary", summary);
     }
 
     if (StringUtils.isNotBlank(news.getAuthor())) {
@@ -247,20 +221,6 @@ public class NewsIndexingServiceConnector extends ElasticIndexingServiceConnecto
     MetadataObject metadataObject = new MetadataObject(NewsUtils.NEWS_METADATA_OBJECT_TYPE, documentId);
     List<MetadataItem> metadataItems = metadataService.getMetadataItemsByObject(metadataObject);
     document.setMetadataItems(metadataItems);
-  }
-
-  private static InitParams getInitParams(String mappingFilePath) {
-    InitParams initParams = new InitParams();
-    ValueParam valueParam = new ValueParam();
-    valueParam.setName(FILE_PATH_PROPERTY_NAME);
-    valueParam.setValue(mappingFilePath);
-    PropertiesParam propertiesParam = new PropertiesParam();
-    propertiesParam.setName("constructor.params");
-    propertiesParam.setProperty(INDEX_ALIAS_PROPERTY_NAME, INDEX_ALIAS_VALUE);
-    propertiesParam.setProperty(INDEX_CURRENT_PROPERTY_NAME, INDEX_CURRENT_VALUE);
-    initParams.addParameter(valueParam);
-    initParams.addParameter(propertiesParam);
-    return initParams;
   }
 
 }

--- a/content-service/src/test/java/io/meeds/news/search/NewsIndexingServiceConnectorTest.java
+++ b/content-service/src/test/java/io/meeds/news/search/NewsIndexingServiceConnectorTest.java
@@ -22,17 +22,12 @@ package io.meeds.news.search;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.util.Date;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
@@ -55,6 +50,8 @@ import io.meeds.news.service.NewsService;
 @RunWith(MockitoJUnitRunner.class)
 public class NewsIndexingServiceConnectorTest {
 
+  NewsIndexingServiceConnector newsIndexingServiceConnector = null;
+
   @Mock
   NewsService                  newsService;
 
@@ -67,16 +64,13 @@ public class NewsIndexingServiceConnectorTest {
   @Mock
   MetadataService              metadataService;
 
-  @InjectMocks
-  NewsIndexingServiceConnector newsIndexingServiceConnector;
-
-  @Before
-  public void setUp() {
-    openMocks(this);
-  }
-
   @Test
   public void testGetAllIds() {
+    newsIndexingServiceConnector = new NewsIndexingServiceConnector(identityManager,
+                                                                    getParams(),
+                                                                    newsService,
+                                                                    activityManager,
+                                                                    metadataService);
     try {
       newsIndexingServiceConnector.getAllIds(0, 10);
       fail("getAllIds shouldn't be supported");
@@ -87,6 +81,12 @@ public class NewsIndexingServiceConnectorTest {
 
   @Test
   public void testCreate() {
+    newsIndexingServiceConnector = new NewsIndexingServiceConnector(identityManager,
+                                                                    getParams(),
+                                                                    newsService,
+                                                                    activityManager,
+                                                                    metadataService);
+
     try {
       newsIndexingServiceConnector.create(null);
       fail("IllegalArgumentException should be thrown");
@@ -129,7 +129,7 @@ public class NewsIndexingServiceConnectorTest {
     posterProfile.setProperty("fullName", "Root Root");
     posterIdentity.setProfile(posterProfile);
     try {
-      when(newsService.getNewsArticleById(anyString())).thenReturn(news);
+      when(newsService.getNewsArticleById("1")).thenReturn(news);
     } catch (Exception e) {
       e.printStackTrace();
     }
@@ -148,4 +148,14 @@ public class NewsIndexingServiceConnectorTest {
     assertNotNull(document.getPermissions());
     assertEquals(1, document.getPermissions().size());
   }
+
+  private InitParams getParams() {
+    InitParams params = new InitParams();
+    PropertiesParam propertiesParam = new PropertiesParam();
+    propertiesParam.setName("constructor.params");
+    params.addParameter(propertiesParam);
+    propertiesParam.setProperty("index_current", "index_name");
+    return params;
+  }
+
 }

--- a/content-webapp/src/main/webapp/WEB-INF/conf/news/search-configuration.xml
+++ b/content-webapp/src/main/webapp/WEB-INF/conf/news/search-configuration.xml
@@ -69,4 +69,25 @@
     </component-plugin>
   </external-component-plugins>
 
+  <external-component-plugins>
+    <target-component>org.exoplatform.commons.search.index.IndexingOperationProcessor</target-component>
+    <component-plugin>
+      <name>NewsIndexingServiceConnector</name>
+      <set-method>addConnector</set-method>
+      <type>io.meeds.news.search.NewsIndexingServiceConnector</type>
+      <description>News ElasticSearch Indexing Connector</description>
+      <init-params>
+        <value-param>
+          <name>mapping.file.path</name>
+          <value>${exo.news.es.mapping.path:jar:/news-es-mapping.json}</value>
+        </value-param>
+        <properties-param>
+          <name>constructor.params</name>
+          <property name="index_alias" value="news_alias" />
+          <property name="index_current" value="news_v1" />
+        </properties-param>
+      </init-params>
+    </component-plugin>
+  </external-component-plugins>
+
 </configuration>


### PR DESCRIPTION
Prior to this change, after updating the NewsIndexingServiceConnector as a Spring component, this connector was added to the IndexingOperationProcessor after its initialization, resulting in the news alias not being created. This change will update the way XML data initialization is used, resolving this issue.