### PR TITLE
fix: Make space manager and super spaces managers allowed to publish news - MEED-7471 - Meeds-io/meeds#2385

### DIFF
--- a/content-service/pom.xml
+++ b/content-service/pom.xml
@@ -36,7 +36,7 @@
     <rest.api.doc.version>1.0</rest.api.doc.version>
     <rest.api.doc.description>Content addon used Rest endpoints</rest.api.doc.description>
 
-    <exo.test.coverage.ratio>0.43</exo.test.coverage.ratio>
+    <exo.test.coverage.ratio>0.53</exo.test.coverage.ratio>
   </properties>
 
   <dependencies>

--- a/content-service/src/main/java/io/meeds/news/service/impl/NewsTargetingServiceImpl.java
+++ b/content-service/src/main/java/io/meeds/news/service/impl/NewsTargetingServiceImpl.java
@@ -97,7 +97,7 @@ public class NewsTargetingServiceImpl implements NewsTargetingService {
                                                Space targetPermissionSpace =
                                                                            spaceService.getSpaceById(targetMetadataPermission.split(SPACE_TARGET_PERMISSION_PREFIX)[1]);
                                                return targetPermissionSpace != null
-                                                   && spaceService.isPublisher(targetPermissionSpace, userIdentity.getUserId());
+                                                   && NewsUtils.canPublishNews(targetPermissionSpace.getId(), userIdentity);
                                              }
                                              return false;
                                            }
@@ -268,7 +268,7 @@ public class NewsTargetingServiceImpl implements NewsTargetingService {
               permissionEntity.setRemoteId(space.getPrettyName());
               permissionEntity.setAvatar(space.getAvatarUrl());
               if (!isSpacePublisher) {
-                isSpacePublisher = spaceService.isPublisher(space, currentIdentity.getUserId());
+                isSpacePublisher = NewsUtils.canPublishNews(space.getId(), currentIdentity);
               }
             }
           }

--- a/content-service/src/main/java/io/meeds/news/utils/NewsUtils.java
+++ b/content-service/src/main/java/io/meeds/news/utils/NewsUtils.java
@@ -85,14 +85,13 @@ public class NewsUtils {
 
   public static final String  ALL_NEWS_AUDIENCE               = "all";
 
-  private static final String PUBLISHER_MEMBERSHIP_NAME       = "publisher";
+  public static final String PUBLISHER_MEMBERSHIP_NAME       = "publisher";
 
-  private static final String MANAGER_MEMBERSHIP_NAME         = "manager";
+  public static final String MANAGER_MEMBERSHIP_NAME         = "manager";
 
-  private static final String PLATFORM_WEB_CONTRIBUTORS_GROUP = "/platform/web-contributors";
+  public static final String PLATFORM_WEB_CONTRIBUTORS_GROUP = "/platform/web-contributors";
 
-  public static final String  SHARE_CONTENT_ATTACHMENTS       = "content.share.attachments";
-
+  public static final String SHARE_CONTENT_ATTACHMENTS       = "content.share.attachments";
 
   public enum NewsObjectType {
     DRAFT, LATEST_DRAFT, ARTICLE;
@@ -190,9 +189,12 @@ public class NewsUtils {
     if (!StringUtils.isBlank(spaceId)) {
       SpaceService spaceService = CommonsUtils.getService(SpaceService.class);
       Space space = spaceService.getSpaceById(spaceId);
-      return currentIdentity != null && space != null && spaceService.isMember(space, currentIdentity.getUserId())
+      return currentIdentity != null
+          && space != null
           && (currentIdentity.isMemberOf(PLATFORM_WEB_CONTRIBUTORS_GROUP, PUBLISHER_MEMBERSHIP_NAME)
-              || spaceService.isPublisher(space, currentIdentity.getUserId()));
+              || spaceService.isPublisher(space, currentIdentity.getUserId())
+              || spaceService.isManager(space, currentIdentity.getUserId())
+              || spaceService.isSuperManager(currentIdentity.getUserId()));
     }
     return currentIdentity != null && currentIdentity.isMemberOf(PLATFORM_WEB_CONTRIBUTORS_GROUP, PUBLISHER_MEMBERSHIP_NAME);
   }

--- a/content-service/src/test/java/io/meeds/news/utils/NewsUtilsTest.java
+++ b/content-service/src/test/java/io/meeds/news/utils/NewsUtilsTest.java
@@ -1,0 +1,96 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2024 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.news.utils;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import org.junit.AfterClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import org.exoplatform.commons.utils.CommonsUtils;
+import org.exoplatform.services.security.Identity;
+import org.exoplatform.social.core.space.model.Space;
+import org.exoplatform.social.core.space.spi.SpaceService;
+
+@RunWith(MockitoJUnitRunner.class)
+public class NewsUtilsTest {
+
+  private static final MockedStatic<CommonsUtils> COMMONS_UTILS = mockStatic(CommonsUtils.class);
+
+  @Mock
+  private SpaceService                            spaceService;
+
+  @Mock
+  private Space                                   space;
+
+  @Mock
+  private Identity                                userAclIdentity;
+
+  @Mock
+  private Identity                                adminAclIdentity;
+
+  @AfterClass
+  public static void afterRunBare() throws Exception { // NOSONAR
+    COMMONS_UTILS.close();
+  }
+
+  @Test
+  public void testCanPublishNews() {
+    when(userAclIdentity.getUserId()).thenReturn("user");
+    when(space.getId()).thenReturn("2");
+
+    assertFalse(NewsUtils.canPublishNews(null, null));
+    COMMONS_UTILS.when(() -> CommonsUtils.getService(SpaceService.class)).thenReturn(spaceService);
+    assertFalse(NewsUtils.canPublishNews(space.getId(), null));
+    assertFalse(NewsUtils.canPublishNews(space.getId(), userAclIdentity));
+
+    when(spaceService.getSpaceById(space.getId())).thenReturn(space);
+
+    assertFalse(NewsUtils.canPublishNews(space.getId(), null));
+    assertFalse(NewsUtils.canPublishNews(space.getId(), userAclIdentity));
+
+    when(adminAclIdentity.isMemberOf(NewsUtils.PLATFORM_WEB_CONTRIBUTORS_GROUP, NewsUtils.PUBLISHER_MEMBERSHIP_NAME)).thenReturn(true);
+    assertTrue(NewsUtils.canPublishNews(space.getId(), adminAclIdentity));
+    assertFalse(NewsUtils.canPublishNews(space.getId(), userAclIdentity));
+
+    lenient().when(spaceService.isMember(space, userAclIdentity.getUserId())).thenReturn(true);
+    assertFalse(NewsUtils.canPublishNews(space.getId(), userAclIdentity));
+    lenient().when(spaceService.isMember(space, userAclIdentity.getUserId())).thenReturn(false);
+
+    when(spaceService.isPublisher(space, userAclIdentity.getUserId())).thenReturn(true);
+    assertTrue(NewsUtils.canPublishNews(space.getId(), userAclIdentity));
+    when(spaceService.isPublisher(space, userAclIdentity.getUserId())).thenReturn(false);
+
+    when(spaceService.isManager(space, userAclIdentity.getUserId())).thenReturn(true);
+    assertTrue(NewsUtils.canPublishNews(space.getId(), userAclIdentity));
+    when(spaceService.isManager(space, userAclIdentity.getUserId())).thenReturn(false);
+
+    when(spaceService.isSuperManager(userAclIdentity.getUserId())).thenReturn(true);
+    assertTrue(NewsUtils.canPublishNews(space.getId(), userAclIdentity));
+  }
+
+}


### PR DESCRIPTION
Prior to this change, the space administrator and the super space manager wasn't able to publish news in a space. This rule was specific to News management. This change will align the ACL rules to be the same as other CMS applications and tools.