### PR TITLE
fix: Add Push Notification Kernel Profile to configuration - MEED-7488 - Meeds-io/MIPs#147

### DIFF
--- a/content-webapp/src/main/webapp/WEB-INF/conf/news/notification/configuration.xml
+++ b/content-webapp/src/main/webapp/WEB-INF/conf/news/notification/configuration.xml
@@ -210,7 +210,7 @@
         </value-param>
       </init-params>
     </component-plugin>
-    <component-plugin>
+    <component-plugin profiles="push-notifications">
       <name>web.channel.content</name>
       <set-method>registerTemplateProvider</set-method>
       <type>io.meeds.news.notification.provider.PushTemplateProvider</type>


### PR DESCRIPTION
Prior to this change, a warning is logged in server console:
`WARN  | Register the new TemplateProvider is unsucessful [o.e.c.n.channel.ChannelManagerImpl`
This change will delete it by restricting Kernel configuration switch availability of `push-notifications` addon in installation which is not added by default in Meeds Package.