### PR TITLE
fix: Fix news list portlet display for admin user - EXO-74536 - Meeds-io/meeds#2451

### DIFF
--- a/content-service/src/main/java/io/meeds/news/rest/NewsRest.java
+++ b/content-service/src/main/java/io/meeds/news/rest/NewsRest.java
@@ -557,7 +557,11 @@ public class NewsRest {
       org.exoplatform.services.security.Identity currentIdentity = ConversationState.getCurrent().getIdentity();
       List<News> news = newsService.getNewsByTargetName(newsFilter, targetName, currentIdentity);
       Locale userLocale = LocalizationFilter.getCurrentLocale();
-      news.forEach(news1 -> news1.setBody(MentionUtils.substituteRoleWithLocale(news1.getBody(), userLocale)));
+      news.forEach(newsArticle -> {
+        if (newsArticle != null) {
+          newsArticle.setBody(MentionUtils.substituteRoleWithLocale(newsArticle.getBody(), userLocale));
+        }
+      });
       newsEntity.setNews(news);
       newsEntity.setOffset(offset);
       newsEntity.setLimit(limit);

--- a/content-service/src/main/java/io/meeds/news/service/impl/NewsServiceImpl.java
+++ b/content-service/src/main/java/io/meeds/news/service/impl/NewsServiceImpl.java
@@ -570,21 +570,29 @@ public class NewsServiceImpl implements NewsService {
                                        newsTargetingService.getNewsTargetItemsByTargetName(targetName, newsFilter.getOffset(), 0);
     return newsTargetItems.stream().filter(target -> {
       try {
-        News news = getNewsArticleById(target.getObjectId());
-        return news != null
-            && (StringUtils.isEmpty(news.getAudience()) || news.getAudience().equals(NewsUtils.ALL_NEWS_AUDIENCE) || news.isSpaceMember());
+        News news = getNewsByIdAndLang(target.getObjectId(),
+                                       currentIdentity,
+                                       false,
+                                       ARTICLE.name().toLowerCase(),
+                                       newsFilter.getLang());
+        return news != null && (StringUtils.isEmpty(news.getAudience()) || news.getAudience().equals(NewsUtils.ALL_NEWS_AUDIENCE)
+            || news.isSpaceMember());
       } catch (Exception e) {
         return false;
       }
     }).map(target -> {
       try {
-        News news = getNewsByIdAndLang(target.getObjectId(), currentIdentity, false, ARTICLE.name().toLowerCase(), newsFilter.getLang());
+        News news = getNewsByIdAndLang(target.getObjectId(),
+                                       currentIdentity,
+                                       false,
+                                       ARTICLE.name().toLowerCase(),
+                                       newsFilter.getLang());
         news.setPublishDate(new Date(target.getCreatedDate()));
         return news;
       } catch (Exception e) {
         return null;
       }
-    }).limit(newsFilter.getLimit()).toList();
+    }).filter(Objects::nonNull).limit(newsFilter.getLimit()).toList();
   }
 
   /**


### PR DESCRIPTION
Prior this change, when a news list portlet have different published articles with audience "all" and audience "space", an admin user see an empty news list portlet block when at least one of the articles published on the news list portlet have audience "space" and the admin user is not member of this article space. After this fix, we ensure that the admin user will not see only the published article with audience "space" when it is not member of this article space and see other published articles (audience "all" or article space member)

Resolves https://github.com/Meeds-io/meeds/issues/2451 