### PR TITLE
fix: [News Slider] Mouse hover makes article content misplaced - EXO-75170 - Meeds-io/meeds#2558.

### DIFF
--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsSliderView.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsSliderView.vue
@@ -57,7 +57,7 @@
                 v-if="showArticleTitle"
                 :href="articleUrl(item)"
                 class="flex flex-row flex-grow-1 align-center justify-center headLinesTruncate"
-                :class="extraClass.concat(canPublishNews && !hover ? 'mt-12' : '')">
+                :class="extraClass.concat(canPublishNews ? 'mt-12' : '')">
                 <span class="text-h4 font-weight-medium white--text text-truncate-2">
                   {{ item.title }}
                 </span>


### PR DESCRIPTION
Before this change, when create news target targeta choosing slider template then publish some news articles in targeta and hover over the targeta sliding articles, article titles and displayed information position changes. To resolve this problem, remove the hover condition to apply class m-12. After this change, article titles keep centered.