### PR TITLE
fix: launch get news list query only once - EXO-75179 - Meeds-io/meeds#2560.

### DIFF
--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/NewsListView.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/NewsListView.vue
@@ -177,6 +177,19 @@ export default {
         seeAllUrl: this.seeAllUrl,
         hasMore: this.hasMore,
         loading: this.loading,
+        selectedOption: {
+          limit: this.limit,
+          showHeader: this.showHeader,
+          showSeeAll: this.showSeeAll,
+          showArticleTitle: this.showArticleTitle,
+          showArticleSummary: this.showArticleSummary,
+          showArticleAuthor: this.showArticleAuthor,
+          showArticleSpace: this.showArticleSpace,
+          showArticleDate: this.showArticleDate,
+          showArticleReactions: this.showArticleReactions,
+          showArticleImage: this.showArticleImage,
+          seeAllUrl: this.seeAllUrl,
+        }
       };
     },
     hideEmptyNewsTemplateForNonPublisher() {

--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsAlertView.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsAlertView.vue
@@ -28,7 +28,7 @@
         <div class="alerts-icon">
           <v-icon>warning</v-icon>
         </div>
-        <span class="d-none d-md-block" v-if="showHeader">{{ newsHeader }}</span>
+        <span class="d-none d-md-block" v-if="showHeader">{{ headerTitle }}</span>
       </div>
 
       <div class="alerts-viewer ps-5 flex-grow-1">
@@ -85,33 +85,28 @@
 <script>
 export default {
   props: {
-    newsTarget: {
+    headerTitle: {
       type: String,
       required: false,
       default: null
+    },
+    newsList: {
+      type: Array,
+      default: () => {
+        return [];
+      }
+    },
+    selectedOption: {
+      type: Object,
+      default: () => {
+        return {};
+      }
     },
   },
   data () {
     return {
       containerNewsAlertView: [],
       slider: 0,
-      news: [],
-      initialized: false,
-      limit: 4,
-      offset: 0,
-
-      showHeader: true,
-      showSeeAll: false,
-      showArticleTitle: true,
-      showArticleSummary: false,
-      showArticleImage: false,
-      showArticleAuthor: false,
-      showArticleSpace: true,
-      showArticleDate: true,
-      showArticleReactions: false,
-      seeAllUrl: '',
-      newsHeader: '',
-      selectedOption: null,
       dateFormat: {
         year: 'numeric',
         month: 'long',
@@ -128,15 +123,24 @@ export default {
       return (item) => {
         return eXo.env.portal.userName !== '' ? item.url : `${eXo.env.portal.context}/${eXo.env.portal.portalName}/news-detail?newsId=${item.id}&type=article`;
       };
-    }
+    },
+    news(){
+      return this.newsList && this.newsList.filter(news => !!news);
+    },
+    showArticleTitle() {
+      return this.selectedOption.showArticleTitle;
+    },
+    showHeader() {
+      return this.selectedOption.showHeader;
+    },
+    showArticleDate() {
+      return this.selectedOption.showArticleDate;
+    },
   },
   created() {
     this.$newsServices.canPublishNews().then(canPublishNews => {
       this.canPublishNews = canPublishNews;
     });
-    this.reset();
-    this.$root.$on('saved-news-settings', this.refreshNewsViews);
-    this.getNewsList();
   },
   methods: {
     disabledContainerNewsAlertView(element,index){
@@ -147,60 +151,6 @@ export default {
     },
     openDrawer() {
       this.$root.$emit('news-settings-drawer-open');
-    },
-    getNewsList() {
-      if (!this.initialized) {
-        this.$newsListService.getNewsList(this.newsTarget, this.offset, this.limit, true)
-          .then(newsList => {
-            this.news = newsList.news.filter(news => !!news);
-            this.initialized = true;
-          })
-          .finally(() => {
-            if (this.emptyTemplate) {
-              this.containerNewsAlertView = document.getElementsByClassName('UIWindow DefaultTheme UIDragObject UIResizeObject');
-              this.containerNewsAlertView.forEach((element,index) => this.disabledContainerNewsAlertView(element,index));
-            }
-            this.initialized = false;
-          });
-      }
-    },
-    refreshNewsViews(selectedTarget, selectedOption) {
-      this.showArticleTitle = selectedOption.showArticleTitle;
-      this.showArticleDate = selectedOption.showArticleDate;
-      this.showHeader = selectedOption.showHeader;
-      this.selectedOption = selectedOption;
-      this.newsHeader = selectedOption.header;
-      this.seeAllUrl = selectedOption.seeAllUrl;
-      this.limit = selectedOption.limit;
-      this.newsTarget = selectedTarget;
-      this.getNewsList();
-    },
-    reset() {
-      this.limit = this.$root.limit;
-      this.showHeader = this.$root.showHeader;
-      this.newsHeader = this.$root.header;
-      this.showSeeAll = this.$root.showSeeAll;
-      this.showArticleTitle = this.$root.showArticleTitle;
-      this.showArticleImage = this.$root.showArticleImage;
-      this.showArticleSummary = this.$root.showArticleSummary;
-      this.showArticleAuthor = this.$root.showArticleAuthor;
-      this.showArticleSpace = this.$root.showArticleSpace;
-      this.showArticleDate = this.$root.showArticleDate;
-      this.showArticleReactions = this.$root.showArticleReactions;
-      this.seeAllUrl = this.$root.seeAllUrl;
-      this.selectedOption = {
-        limit: this.limit,
-        showHeader: this.showHeader,
-        showSeeAll: this.showSeeAll,
-        showArticleTitle: this.showArticleTitle,
-        showArticleSummary: this.showArticleSummary,
-        showArticleAuthor: this.showArticleAuthor,
-        showArticleSpace: this.showArticleSpace,
-        showArticleDate: this.showArticleDate,
-        showArticleReactions: this.showArticleReactions,
-        showArticleImage: this.showArticleImage,
-        seeAllUrl: this.seeAllUrl,
-      };
     },
   }
 };

--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsCardsView.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsCardsView.vue
@@ -33,84 +33,23 @@
 <script>
 export default {
   props: {
-    newsTarget: {
-      type: String,
-      required: false,
-      default: null
-    },
-  },
-  data () {
-    return {
-      news: [],
-      initialized: false,
-      limit: 10,
-      offset: 0,
-
-      showHeader: true,
-      showSeeAll: true,
-      showArticleTitle: true,
-      showArticleSummary: true,
-      showArticleImage: true,
-      showArticleAuthor: true,
-      showArticleSpace: true,
-      showArticleDate: true,
-      showArticleReactions: true,
-      seeAllUrl: '',
-      selectedOption: null,
-    };
-  },
-  created() {
-    this.reset();
-    this.$root.$on('saved-news-settings', this.refreshNewsViews);
-    this.getNewsList();
-  },
-  methods: {
-    getNewsList() {
-      if (!this.initialized) {
-        this.$newsListService.getNewsList(this.newsTarget, this.offset, this.limit, true)
-          .then(newsList => {
-            this.news = newsList.news.filter(news => !!news);
-            this.initialized = true;
-          })
-          .finally(() => this.initialized = false);
+    newsList: {
+      type: Array,
+      default: () => {
+        return [];
       }
     },
-    refreshNewsViews(selectedTarget, selectedOption) {
-      this.showArticleSummary = selectedOption.showArticleSummary;
-      this.showArticleTitle = selectedOption.showArticleTitle;
-      this.showArticleImage = selectedOption.showArticleImage;
-      this.seeAllUrl = selectedOption.seeAllUrl;
-      this.limit = selectedOption.limit;
-      this.selectedOption = selectedOption;
-      this.newsTarget = selectedTarget;
-      this.getNewsList();
+    selectedOption: {
+      type: Object,
+      default: () => {
+        return {};
+      }
     },
-    reset() {
-      this.limit = this.$root.limit;
-      this.showHeader = this.$root.showHeader;
-      this.showSeeAll = this.$root.showSeeAll;
-      this.showArticleTitle = this.$root.showArticleTitle;
-      this.showArticleImage = this.$root.showArticleImage;
-      this.showArticleSummary = this.$root.showArticleSummary;
-      this.showArticleAuthor = this.$root.showArticleAuthor;
-      this.showArticleSpace = this.$root.showArticleSpace;
-      this.showArticleDate = this.$root.showArticleDate;
-      this.showArticleReactions = this.$root.showArticleReactions;
-      this.seeAllUrl = this.$root.seeAllUrl;
-      this.selectedOption = {
-        limit: this.limit,
-        showHeader: this.showHeader,
-        showSeeAll: this.showSeeAll,
-        showArticleTitle: this.showArticleTitle,
-        showArticleSummary: this.showArticleSummary,
-        showArticleAuthor: this.showArticleAuthor,
-        showArticleSpace: this.showArticleSpace,
-        showArticleDate: this.showArticleDate,
-        showArticleReactions: this.showArticleReactions,
-        showArticleImage: this.showArticleImage,
-        seeAllUrl: this.seeAllUrl,
-      };
+  },
+  computed: {
+    news(){
+      return this.newsList && this.newsList.filter(news => !!news);
     },
-  }
+  },
 };
 </script>

--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsLatestView.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsLatestView.vue
@@ -50,11 +50,6 @@
 <script>
 export default {
   props: {
-    newsTarget: {
-      type: Object,
-      required: false,
-      default: null
-    },
     newsList: {
       type: Array,
       default: () => {
@@ -64,34 +59,15 @@ export default {
     loading: {
       type: Boolean,
       default: false
-    }
+    },
+    selectedOption: {
+      type: Object,
+      default: () => {
+        return {};
+      }
+    },
   },
   data: ()=> ({
-    initialized: false,
-    limit: 4,
-    offset: 0,
-    space: null,
-    isHovered: false,
-    commentsSize: 0,
-    likeSize: 0,
-    fullDateFormat: {
-      year: 'numeric',
-      month: 'short',
-      day: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit',
-    },
-    seeAllUrl: '',
-    selectedOption: null,
-    showHeader: false,
-    showSeeAll: false,
-    showArticleTitle: false,
-    showArticleSummary: false,
-    showArticleImage: false,
-    showArticleAuthor: false,
-    showArticleSpace: false,
-    showArticleDate: false,
-    showArticleReactions: false,
     hasSmallWidthContainer: false,
     canPublishNews: false,
   }),
@@ -100,56 +76,17 @@ export default {
       return this.newsList && this.newsList.filter(news => !!news);
     },
     extraClass() {
-      return (!this.showHeader && !this.showSeeAll && !this.canPublishNews ) && 'mt-5' || ' ';
+      return (!this.selectedOption.showHeader && !this.selectedOption.showSeeAll && !this.canPublishNews ) && 'mt-5' || ' ';
     }
   },
   created() {
-    this.reset();
     this.$newsServices.canPublishNews().then(canPublishNews => {
       this.canPublishNews = canPublishNews;
     });
-    this.$root.$on('saved-news-settings', this.refreshNewsViews);
   },
   mounted() {
     this.$nextTick().then(() => this.$root.$emit('application-loaded'));
     this.hasSmallWidthContainer = (this.$refs['news-latest-view']?.clientWidth *100 / window.screen.width) < 33;
   },
-  methods: {
-    refreshNewsViews(selectedTarget, selectedOption){
-      this.selectedOption = selectedOption;
-      this.newsHeader = selectedOption.header;
-      this.seeAllUrl = selectedOption.seeAllUrl;
-      this.limit = selectedOption.limit;
-      this.newsTarget = selectedTarget;
-      this.getNewsList();
-    },
-    reset() {
-      this.limit = this.$root.limit;
-      this.showHeader = this.$root.showHeader;
-      this.newsHeader = this.$root.header;
-      this.showSeeAll = this.$root.showSeeAll;
-      this.showArticleTitle = this.$root.showArticleTitle;
-      this.showArticleImage = this.$root.showArticleImage;
-      this.showArticleSummary = this.$root.showArticleSummary;
-      this.showArticleAuthor = this.$root.showArticleAuthor;
-      this.showArticleSpace = this.$root.showArticleSpace;
-      this.showArticleDate = this.$root.showArticleDate;
-      this.showArticleReactions = this.$root.showArticleReactions;
-      this.seeAllUrl = this.$root.seeAllUrl;
-      this.selectedOption = {
-        limit: this.limit,
-        showHeader: this.showHeader,
-        showSeeAll: this.showSeeAll,
-        showArticleTitle: this.showArticleTitle,
-        showArticleSummary: this.showArticleSummary,
-        showArticleAuthor: this.showArticleAuthor,
-        showArticleSpace: this.showArticleSpace,
-        showArticleDate: this.showArticleDate,
-        showArticleReactions: this.showArticleReactions,
-        showArticleImage: this.showArticleImage,
-        seeAllUrl: this.seeAllUrl,
-      };
-    },
-  }
 };
 </script>

--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsListTemplateView.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsListTemplateView.vue
@@ -44,29 +44,20 @@
 <script>
 export default {
   props: {
-    newsTarget: {
+    newsList: {
+      type: Array,
+      default: () => {
+        return [];
+      }
+    },
+    selectedOption: {
       type: Object,
-      required: false,
-      default: null
+      default: () => {
+        return {};
+      }
     },
   },
   data: () => ({
-    initialized: false,
-    newsInfo: null,
-    limit: 4,
-    offset: 0,
-    space: null,
-    seeAllUrl: '',
-    selectedOption: null,
-    showHeader: true,
-    showSeeAll: true,
-    showArticleTitle: true,
-    showArticleSummary: true,
-    showArticleImage: true,
-    showArticleAuthor: true,
-    showArticleSpace: true,
-    showArticleDate: true,
-    showArticleReactions: true,
     canPublishNews: false,
     parentWidth: 0
   }),
@@ -74,15 +65,15 @@ export default {
     numberOfColumns(){
       const thresholds = this.$vuetify.breakpoint?.thresholds;
       return this.parentWidth < thresholds.sm ? 12 : this.parentWidth < thresholds.md ? 6 : this.parentWidth < thresholds.lg ? 4 : 3;
+    },
+    newsInfo(){
+      return this.newsList && this.newsList.filter(news => !!news);
     }
   },
   created() {
     this.$newsServices.canPublishNews().then(canPublishNews => {
       this.canPublishNews = canPublishNews;
     });
-    this.reset();
-    this.$root.$on('saved-news-settings', this.refreshNewsViews);
-    this.getNewsList();
   },
   mounted() {
     // get the initial width of the parent element
@@ -94,55 +85,5 @@ export default {
     });
     this.$nextTick().then(() => this.$root.$emit('application-loaded'));
   },
-  methods: {
-    getNewsList() {
-      if (!this.initialized) {
-        this.$newsListService.getNewsList(this.newsTarget, this.offset, this.limit, true)
-          .then(newsList => {
-            this.newsInfo = newsList.news.filter(news => !!news);
-            this.initialized = true;
-          })
-          .finally(() => this.initialized = false);
-      }
-    },
-    refreshNewsViews(selectedTarget, selectedOption) {
-      this.showArticleSummary = selectedOption.showArticleSummary;
-      this.showArticleTitle = selectedOption.showArticleTitle;
-      this.showArticleImage = selectedOption.showArticleImage;
-      this.selectedOption = selectedOption;
-      this.newsHeader = selectedOption.header;
-      this.seeAllUrl = selectedOption.seeAllUrl;
-      this.limit = selectedOption.limit;
-      this.newsTarget = selectedTarget;
-      this.getNewsList();
-    },
-    reset() {
-      this.limit = this.$root.limit;
-      this.showHeader = this.$root.showHeader;
-      this.newsHeader = this.$root.header;
-      this.showSeeAll = this.$root.showSeeAll;
-      this.showArticleTitle = this.$root.showArticleTitle;
-      this.showArticleImage = this.$root.showArticleImage;
-      this.showArticleSummary = this.$root.showArticleSummary;
-      this.showArticleAuthor = this.$root.showArticleAuthor;
-      this.showArticleSpace = this.$root.showArticleSpace;
-      this.showArticleDate = this.$root.showArticleDate;
-      this.showArticleReactions = this.$root.showArticleReactions;
-      this.seeAllUrl = this.$root.seeAllUrl;
-      this.selectedOption = {
-        limit: this.limit,
-        showHeader: this.showHeader,
-        showSeeAll: this.showSeeAll,
-        showArticleTitle: this.showArticleTitle,
-        showArticleSummary: this.showArticleSummary,
-        showArticleAuthor: this.showArticleAuthor,
-        showArticleSpace: this.showArticleSpace,
-        showArticleDate: this.showArticleDate,
-        showArticleReactions: this.showArticleReactions,
-        showArticleImage: this.showArticleImage,
-        seeAllUrl: this.seeAllUrl,
-      };
-    },
-  }
 };
 </script>

--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsMosaicView.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsMosaicView.vue
@@ -63,31 +63,21 @@
 <script>
 export default {
   props: {
-    newsTarget: {
-      type: String,
-      required: false,
-      default: null
+    newsList: {
+      type: Array,
+      default: () => {
+        return [];
+      }
+    },
+    selectedOption: {
+      type: Object,
+      default: () => {
+        return {};
+      }
     },
   },
   data () {
     return {
-      news: [],
-      initialized: false,
-      limit: 4,
-      offset: 0,
-
-      showHeader: false,
-      showSeeAll: true,
-      showArticleTitle: true,
-      showArticleSummary: false,
-      showArticleImage: true,
-      showArticleAuthor: true,
-      showArticleSpace: true,
-      showArticleDate: true,
-      showArticleReactions: true,
-      seeAllUrl: '',
-      newsHeader: '',
-      selectedOption: null,
       dateFormat: {
         year: 'numeric',
         month: 'long',
@@ -96,11 +86,6 @@ export default {
       isSmallWidth: false
     };
   },
-  created() {
-    this.reset();
-    this.$root.$on('saved-news-settings', this.refreshNewsViews);
-    this.getNewsList();
-  },
   mounted() {
     this.isSmallWidth =  this.$refs?.['top-news-mosaic']?.clientWidth < 600;
     window.addEventListener('resize', () => {
@@ -108,6 +93,15 @@ export default {
     });
   },
   computed: {
+    showArticleTitle() {
+      return this.selectedOption.showArticleTitle;
+    },
+    showArticleImage() {
+      return this.selectedOption.showArticleImage;
+    },
+    showArticleDate() {
+      return this.selectedOption.showArticleDate;
+    },
     isMobile() {
       return this.$vuetify.breakpoint.name === 'xs' || this.$vuetify.breakpoint.name === 'sm' || this.$vuetify.breakpoint.name === 'md';
     },
@@ -121,59 +115,14 @@ export default {
       return (item) => {
         return eXo.env.portal.userName !== '' ? item.url : `${eXo.env.portal.context}/${eXo.env.portal.portalName}/news-detail?newsId=${item.id}&type=article`;
       };
-    }
+    },
+    news(){
+      return this.newsList && this.newsList.filter(news => !!news);
+    },
   },
   methods: {
-    getNewsList() {
-      if (!this.initialized) {
-        this.$newsListService.getNewsList(this.newsTarget, this.offset, this.limit, true)
-          .then(newsList => {
-            this.news = newsList.news.filter(news => !!news);
-            this.initialized = true;
-          })
-          .finally(() => this.initialized = false);
-      }
-    },
     minLength(lengthNews){
       return lengthNews < 5 && lengthNews > 0 ? 100 / lengthNews : 25;
-    },
-    refreshNewsViews(selectedTarget, selectedOption) {
-      this.showArticleTitle = selectedOption.showArticleTitle;
-      this.showArticleDate = selectedOption.showArticleDate;
-      this.showHeader = selectedOption.showHeader;
-      this.selectedOption = selectedOption;
-      this.newsHeader = selectedOption.header;
-      this.seeAllUrl = selectedOption.seeAllUrl;
-      this.limit = selectedOption.limit;
-      this.newsTarget = selectedTarget;
-      this.getNewsList();
-    },
-    reset() {
-      this.limit = this.$root.limit;
-      this.showHeader = this.$root.showHeader;
-      this.newsHeader = this.$root.header;
-      this.showSeeAll = this.$root.showSeeAll;
-      this.showArticleTitle = this.$root.showArticleTitle;
-      this.showArticleImage = this.$root.showArticleImage;
-      this.showArticleSummary = this.$root.showArticleSummary;
-      this.showArticleAuthor = this.$root.showArticleAuthor;
-      this.showArticleSpace = this.$root.showArticleSpace;
-      this.showArticleDate = this.$root.showArticleDate;
-      this.showArticleReactions = this.$root.showArticleReactions;
-      this.seeAllUrl = this.$root.seeAllUrl;
-      this.selectedOption = {
-        limit: this.limit,
-        showHeader: this.showHeader,
-        showSeeAll: this.showSeeAll,
-        showArticleTitle: this.showArticleTitle,
-        showArticleSummary: this.showArticleSummary,
-        showArticleAuthor: this.showArticleAuthor,
-        showArticleSpace: this.showArticleSpace,
-        showArticleDate: this.showArticleDate,
-        showArticleReactions: this.showArticleReactions,
-        showArticleImage: this.showArticleImage,
-        seeAllUrl: this.seeAllUrl,
-      };
     },
     styleArticleTitle(){
       return  (this.isSmallWidth ? 'articleTitle ' : '').concat(this.isSmallBreakpoint ? 'text-truncate' : 'articleTitleTruncate');

--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsSliderView.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsSliderView.vue
@@ -91,40 +91,21 @@
 <script>
 export default {
   props: {
-    newsTarget: {
-      type: String,
-      required: false,
-      default: 'snapshotSliderNews'
-    },
     newsList: {
       type: Array,
       default: () => {
         return [];
       }
     },
+    selectedOption: {
+      type: Object,
+      default: () => {
+        return {};
+      }
+    },
   },
   data () {
     return {
-      limit: 4,
-      offset: 0,
-      fullDateFormat: {
-        year: 'numeric',
-        month: 'short',
-        day: 'numeric',
-        hour: '2-digit',
-        minute: '2-digit',
-      },
-      showHeader: false,
-      showSeeAll: false,
-      showArticleTitle: true,
-      showArticleSummary: true,
-      showArticleImage: true,
-      showArticleAuthor: true,
-      showArticleSpace: true,
-      showArticleDate: true,
-      showArticleReactions: true,
-      seeAllUrl: '',
-      selectedOption: null,
       canPublishNews: false,
     };
   },
@@ -139,54 +120,25 @@ export default {
       return (item) => {
         return eXo.env.portal.userName !== '' ? item.url : `${eXo.env.portal.context}/${eXo.env.portal.portalName}/news-detail?newsId=${item.id}&type=article`;
       };
-    }
+    },
+    showArticleTitle() {
+      return this.selectedOption.showArticleTitle;
+    },
+    showArticleImage() {
+      return this.selectedOption.showArticleImage;
+    },
+    showArticleSummary() {
+      return this.selectedOption.showArticleSummary;
+    },
   },
   created() {
     this.$newsServices.canPublishNews().then(canPublishNews => {
       this.canPublishNews = canPublishNews;
     });
-    this.reset();
-    this.$root.$on('saved-news-settings', this.refreshNewsViews);
   },
   methods: {
     openDrawer() {
       this.$root.$emit('news-settings-drawer-open');
-    },
-    refreshNewsViews(selectedTarget, selectedOption){
-      this.showArticleSummary = selectedOption.showArticleSummary;
-      this.showArticleTitle = selectedOption.showArticleTitle;
-      this.showArticleImage = selectedOption.showArticleImage;
-      this.seeAllUrl = selectedOption.seeAllUrl;
-      this.limit = selectedOption.limit;
-      this.selectedOption = selectedOption;
-      this.newsTarget = selectedTarget;
-      this.getNewsList();
-    },
-    reset() {
-      this.limit = this.$root.limit;
-      this.showHeader = this.$root.showHeader;
-      this.showSeeAll = this.$root.showSeeAll;
-      this.showArticleTitle = this.$root.showArticleTitle;
-      this.showArticleImage = this.$root.showArticleImage;
-      this.showArticleSummary = this.$root.showArticleSummary;
-      this.showArticleAuthor = this.$root.showArticleAuthor;
-      this.showArticleSpace = this.$root.showArticleSpace;
-      this.showArticleDate = this.$root.showArticleDate;
-      this.showArticleReactions = this.$root.showArticleReactions;
-      this.seeAllUrl = this.$root.seeAllUrl;
-      this.selectedOption = {
-        limit: this.limit,
-        showHeader: this.showHeader,
-        showSeeAll: this.showSeeAll,
-        showArticleTitle: this.showArticleTitle,
-        showArticleSummary: this.showArticleSummary,
-        showArticleAuthor: this.showArticleAuthor,
-        showArticleSpace: this.showArticleSpace,
-        showArticleDate: this.showArticleDate,
-        showArticleReactions: this.showArticleReactions,
-        showArticleImage: this.showArticleImage,
-        seeAllUrl: this.seeAllUrl,
-      };
     },
   }
 };

--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsStoriesView.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsStoriesView.vue
@@ -65,84 +65,29 @@
 <script>
 export default {
   props: {
-    newsTarget: {
-      type: String,
-      required: false,
-      default: null
-    },
-  },
-  data () {
-    return {
-      news: [],
-      initialized: false,
-      limit: 10,
-      offset: 0,
-
-      showHeader: false,
-      showSeeAll: false,
-      showArticleTitle: true,
-      showArticleSummary: false,
-      showArticleImage: true,
-      showArticleAuthor: true,
-      showArticleSpace: false,
-      showArticleDate: true,
-      showArticleReactions: true,
-      seeAllUrl: '',
-      selectedOption: null,
-    };
-  },
-  created() {
-    this.reset();
-    this.$root.$on('saved-news-settings', this.refreshNewsViews);
-    this.getNewsList();
-  },
-  methods: {
-    getNewsList() {
-      if (!this.initialized) {
-        this.$newsListService.getNewsList(this.newsTarget, this.offset, this.limit, true)
-          .then(newsList => {
-            this.news = newsList.news.filter(news => !!news);
-            this.initialized = true;
-          })
-          .finally(() => this.initialized = false);
+    newsList: {
+      type: Array,
+      default: () => {
+        return [];
       }
     },
-    refreshNewsViews(selectedTarget, selectedOption) {
-      this.showArticleSummary = selectedOption.showArticleSummary;
-      this.showArticleTitle = selectedOption.showArticleTitle;
-      this.showArticleImage = selectedOption.showArticleImage;
-      this.seeAllUrl = selectedOption.seeAllUrl;
-      this.limit = selectedOption.limit;
-      this.selectedOption = selectedOption;
-      this.newsTarget = selectedTarget;
-      this.getNewsList();
+    selectedOption: {
+      type: Object,
+      default: () => {
+        return {};
+      }
     },
-    reset() {
-      this.limit = this.$root.limit;
-      this.showHeader = this.$root.showHeader;
-      this.showSeeAll = this.$root.showSeeAll;
-      this.showArticleTitle = this.$root.showArticleTitle;
-      this.showArticleImage = this.$root.showArticleImage;
-      this.showArticleSummary = this.$root.showArticleSummary;
-      this.showArticleAuthor = this.$root.showArticleAuthor;
-      this.showArticleSpace = this.$root.showArticleSpace;
-      this.showArticleDate = this.$root.showArticleDate;
-      this.showArticleReactions = this.$root.showArticleReactions;
-      this.seeAllUrl = this.$root.seeAllUrl;
-      this.selectedOption = {
-        limit: this.limit,
-        showHeader: this.showHeader,
-        showSeeAll: this.showSeeAll,
-        showArticleTitle: this.showArticleTitle,
-        showArticleSummary: this.showArticleSummary,
-        showArticleAuthor: this.showArticleAuthor,
-        showArticleSpace: this.showArticleSpace,
-        showArticleDate: this.showArticleDate,
-        showArticleReactions: this.showArticleReactions,
-        showArticleImage: this.showArticleImage,
-        seeAllUrl: this.seeAllUrl,
-      };
+  },
+  computed: {
+    news(){
+      return this.newsList && this.newsList.filter(news => !!news);
     },
-  }
+    showSeeAll() {
+      return this.selectedOption.showSeeAll;
+    },
+    seeAllUrl() {
+      return this.selectedOption.seeAllUrl;
+    },
+  },
 };
 </script>


### PR DESCRIPTION
Before this change, when on global stream add news list and choose any template for display and open inspect mode and check call of api (contents/byTarget) in filter, the request is called 2 times which will necessarily impact the performance. To resolve this problem, delete the API call (contents/byTarget) in all news templates. After this change, the query is called only once which improves performance.