### PR TITLE
fix: fix publish article from empty note default home page - EXO-73041 - Meeds-io/MIPs#161

### DIFF
--- a/content-service/src/main/java/io/meeds/news/service/impl/NewsServiceImpl.java
+++ b/content-service/src/main/java/io/meeds/news/service/impl/NewsServiceImpl.java
@@ -238,20 +238,21 @@ public class NewsServiceImpl implements NewsService {
 
   @Override
   public News postNews(News news, String poster) throws Exception {
-    if (news.getPublicationState().equals(STAGED) || news.getSchedulePostDate() != null) {
+    if (news == null || poster == null || poster.isBlank()) {
+      throw new IllegalArgumentException("News and poster cannot be null or empty.");
+    }
+
+    if (STAGED.equals(news.getPublicationState()) || news.getSchedulePostDate() != null) {
       news = postScheduledArticle(news);
     } else if (!news.isFromDraft() && noteService.getNoteById(news.getId()) != null) {
       news = createArticleFromExistingPage(news, poster);
     } else {
       news = createNewsArticlePage(news, poster);
     }
-    postNewsActivity(news);
-    sendNotification(poster, news, NotificationConstants.NOTIFICATION_CONTEXT.POST_NEWS);
-    if (news.isPublished()) {
-      publishNews(news, poster);
+
+    if (news != null) {
+      postProcessing(news, poster);
     }
-    NewsUtils.broadcastEvent(NewsUtils.POST_NEWS_ARTICLE, news.getId(), news);// Gamification
-    NewsUtils.broadcastEvent(NewsUtils.POST_NEWS, news.getAuthor(), news);// Analytics
     return news;
   }
 
@@ -1178,6 +1179,23 @@ public class NewsServiceImpl implements NewsService {
   @Override
   public List<String> getArticleLanguages(String articleId, boolean withDrafts) throws WikiException {
     return noteService.getPageAvailableTranslationLanguages(Long.parseLong(articleId), withDrafts);
+  }
+
+  private void postProcessing(News news, String poster) throws Exception {
+    if (news.getAuthor() == null) {
+      news.setAuthor(poster);
+    }
+
+    postNewsActivity(news);
+    sendNotification(poster, news, NotificationConstants.NOTIFICATION_CONTEXT.POST_NEWS);
+
+    if (news.isPublished()) {
+      publishNews(news, poster);
+    }
+
+    // Broadcast events for gamification and analytics
+    NewsUtils.broadcastEvent(NewsUtils.POST_NEWS_ARTICLE, news.getId(), news);
+    NewsUtils.broadcastEvent(NewsUtils.POST_NEWS, news.getAuthor(), news);
   }
   
   private void buildNewArticleProperties(News article,

--- a/content-service/src/test/java/io/meeds/news/service/impl/NewsServiceImplTest.java
+++ b/content-service/src/test/java/io/meeds/news/service/impl/NewsServiceImplTest.java
@@ -560,6 +560,11 @@ public class NewsServiceImplTest {
             anyMap(),
             anyLong(),
             anyBoolean());
+    
+    clearInvocations(activityManager);
+    newsArticlePage.setAuthor(null);
+    newsService.createNews(newsArticle, identity);
+    verify(activityManager, times(1)).saveActivityNoReturn(any(), any());
   }
 
   @Test


### PR DESCRIPTION
prior to this change, when try to publish newly created default note home page, an exception is thrown as the note is auto created without specifying the author. 
This PR ensures to set the poster as author during the publish process.