### PR TITLE
feat: Clear activity cache of published note when note is updated - EXO-73042 - Meeds-io/MIPs#161

### DIFF
--- a/content-service/src/main/java/io/meeds/news/listener/ExternalArticlePageListener.java
+++ b/content-service/src/main/java/io/meeds/news/listener/ExternalArticlePageListener.java
@@ -1,0 +1,72 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2024 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+package io.meeds.news.listener;
+
+import io.meeds.news.model.News;
+import io.meeds.news.service.NewsService;
+import jakarta.annotation.PostConstruct;
+import org.exoplatform.services.listener.Event;
+import org.exoplatform.services.listener.Listener;
+import org.exoplatform.services.listener.ListenerService;
+import org.exoplatform.social.core.storage.api.ActivityStorage;
+import org.exoplatform.social.core.storage.cache.CachedActivityStorage;
+import org.exoplatform.wiki.model.Page;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ExternalArticlePageListener extends Listener<String, Page> {
+
+  private final ListenerService listenerService;
+
+  private final NewsService     newsService;
+
+  private CachedActivityStorage cachedActivityStorage;
+
+  private static final String[] LISTENER_EVENTS = { "note.updated" };
+
+  @Autowired
+  public ExternalArticlePageListener(ListenerService listenerService, NewsService newsService, ActivityStorage activityStorage) {
+    this.listenerService = listenerService;
+    this.newsService = newsService;
+    if (activityStorage instanceof CachedActivityStorage) {
+      this.cachedActivityStorage = (CachedActivityStorage) activityStorage;
+    }
+  }
+
+  @PostConstruct
+  public void init() {
+    for (String listener : LISTENER_EVENTS) {
+      listenerService.addListener(listener, this);
+    }
+  }
+
+  @Override
+  public void onEvent(Event<String, Page> event) throws Exception {
+    Page page = event.getData();
+    if (page != null) {
+      News news = newsService.getNewsArticleById(page.getId());
+      if (news != null && news.getActivityId() != null) {
+        cachedActivityStorage.clearActivityCached(news.getActivityId());
+      }
+    }
+  }
+}

--- a/content-service/src/test/java/io/meeds/news/listener/ExternalArticlePageListenerTest.java
+++ b/content-service/src/test/java/io/meeds/news/listener/ExternalArticlePageListenerTest.java
@@ -1,0 +1,59 @@
+package io.meeds.news.listener;
+
+import io.meeds.news.model.News;
+import io.meeds.news.service.NewsService;
+import org.exoplatform.services.listener.Event;
+import org.exoplatform.services.listener.ListenerService;
+import org.exoplatform.social.core.storage.api.ActivityStorage;
+import org.exoplatform.social.core.storage.cache.CachedActivityStorage;
+import org.exoplatform.wiki.model.Page;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.lang.reflect.Field;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ExternalArticlePageListenerTest {
+
+  @Mock
+  private ListenerService             listenerService;
+
+  @Mock
+  private NewsService                 newsService;
+
+  @Mock
+  private ActivityStorage             activityStorage;
+
+  @Mock
+  private CachedActivityStorage       cachedActivityStorage;
+
+  private ExternalArticlePageListener externalArticlePageListener;
+
+  @Before
+  public void setUp() throws Exception {
+    this.externalArticlePageListener = new ExternalArticlePageListener(listenerService, newsService, activityStorage);
+    Field field = this.externalArticlePageListener.getClass().getDeclaredField("cachedActivityStorage");
+    field.setAccessible(true);
+    field.set(externalArticlePageListener, cachedActivityStorage);
+  }
+
+  @Test
+  public void onEvent() throws Exception {
+    News article = new News();
+    article.setId("1");
+    article.setActivityId("1");
+    Page note = new Page();
+    note.setId("1");
+    note.setWikiOwner("/spaces/space");
+    note.setContent("tes");
+    Event<String, Page> event = new Event<>("note.updated", "user", note);
+    when(newsService.getNewsArticleById("1")).thenReturn(article);
+    externalArticlePageListener.onEvent(event);
+    verify(cachedActivityStorage, times(1)).clearActivityCached("1");
+  }
+}


### PR DESCRIPTION
Clear activity cache of published note when note is updated