### PR TITLE
feat: Disallow space members from editing or removing articles they did not author - EXO-75398 - Meeds-io/meeds#2603 (#315)

### DIFF
--- a/content-service/src/main/java/io/meeds/news/service/impl/NewsServiceImpl.java
+++ b/content-service/src/main/java/io/meeds/news/service/impl/NewsServiceImpl.java
@@ -509,7 +509,7 @@ public class NewsServiceImpl implements NewsService {
         throw new IllegalAccessException("User " + currentIdentity.getUserId() + " is not authorized to view News");
       }
       news.setCanEdit(canEditNews(news, currentIdentity.getUserId()));
-      news.setCanDelete(canDeleteNews(currentIdentity, news.getAuthor(), news.getSpaceId()));
+      news.setCanDelete(canDeleteNews(currentIdentity, news));
       news.setCanPublish(NewsUtils.canPublishNews(news.getSpaceId(), currentIdentity));
       Space space = spaceService.getSpaceById(news.getSpaceId());
       if (space != null) {
@@ -575,7 +575,7 @@ public class NewsServiceImpl implements NewsService {
     }
     newsList.stream().filter(Objects::nonNull).forEach(news -> {
       news.setCanEdit(canEditNews(news, currentIdentity.getUserId()));
-      news.setCanDelete(canDeleteNews(currentIdentity, news.getAuthor(), news.getSpaceId()));
+      news.setCanDelete(canDeleteNews(currentIdentity, news));
       news.setCanPublish(NewsUtils.canPublishNews(news.getSpaceId(), currentIdentity));
       Space space = spaceService.getSpaceById(news.getSpaceId());
       if (space != null) {
@@ -1514,16 +1514,28 @@ public class NewsServiceImpl implements NewsService {
       LOG.warn("Can't find user with id {} when checking access on news with id {}", authenticatedUser, news.getId());
       return false;
     }
-    return NewsUtils.canPublishNews(news.getSpaceId(), authenticatedUserIdentity)
-        || spaceService.canRedactOnSpace(space, authenticatedUserIdentity);
+    boolean isSpaceMemberCanEdit = isArticleAuthor(news, authenticatedUser) && spaceService.isMember(spaceId, authenticatedUser);
+    return  isSpaceMemberCanEdit || NewsUtils.canPublishNews(news.getSpaceId(), authenticatedUserIdentity)
+        || (spaceService.isManager(space, authenticatedUser)
+            || spaceService.isSuperManager(space, authenticatedUser)
+            || spaceService.isRedactor(space, authenticatedUser));
   }
 
-  private boolean canDeleteNews(Identity currentIdentity, String posterId, String spaceId) {
-    Space space = spaceId == null ? null : spaceService.getSpaceById(spaceId);
+  private boolean isArticleAuthor(News article, String userName) {
+    return StringUtils.isNotEmpty(article.getAuthor()) && article.getAuthor().equals(userName);
+  }
+  
+  private boolean canDeleteNews(Identity currentIdentity, News news) {
+    Space space = news.getSpaceId() == null ? null : spaceService.getSpaceById(news.getSpaceId());
     if (space == null) {
       return false;
     }
-    return spaceService.canRedactOnSpace(space, currentIdentity);
+    boolean isMemberCanDelete = isArticleAuthor(news, currentIdentity.getUserId())
+        && spaceService.isMember(space.getId(), currentIdentity.getUserId());
+    return isMemberCanDelete || NewsUtils.canPublishNews(news.getSpaceId(), currentIdentity)
+        || (spaceService.isManager(space, currentIdentity.getUserId())
+            || spaceService.isSuperManager(space, currentIdentity.getUserId())
+            || spaceService.isRedactor(space, currentIdentity.getUserId()));
   }
 
   private boolean canViewSharedInSpaces(News news, String username) {

--- a/content-service/src/test/java/io/meeds/news/service/impl/NewsServiceImplTest.java
+++ b/content-service/src/test/java/io/meeds/news/service/impl/NewsServiceImplTest.java
@@ -319,7 +319,7 @@ public class NewsServiceImplTest {
     assertThrows(IllegalAccessException.class, () -> newsService.updateNews(news, "john", false, false, NewsUtils.NewsObjectType.DRAFT.name().toLowerCase(), CONTENT_AND_TITLE.name()));
 
     // Given
-    when(spaceService.canRedactOnSpace(space, identity)).thenReturn(true);
+    when(spaceService.isSuperManager(any(Space.class), anyString())).thenReturn(true);
     org.exoplatform.social.core.identity.model.Identity identity1 =
                                                                   mock(org.exoplatform.social.core.identity.model.Identity.class);
     when(identityManager.getOrCreateUserIdentity(anyString())).thenReturn(identity1);
@@ -364,9 +364,13 @@ public class NewsServiceImplTest {
     when(rootPage.getName()).thenReturn(NEWS_ARTICLES_ROOT_NOTE_PAGE_NAME);
     when(noteService.getDraftNoteById(anyString(), anyString())).thenReturn(draftPage);
     NEWS_UTILS.when(() -> NewsUtils.getUserIdentity(anyString())).thenReturn(identity);
-    when(spaceService.canRedactOnSpace(space, identity)).thenReturn(true);
+
+    //
+    assertThrows(IllegalAccessException.class, () -> newsService.deleteNews(draftPage.getId(), identity, NewsUtils.NewsObjectType.DRAFT.name().toLowerCase()));
 
     // When
+    when(spaceService.isSuperManager(any(Space.class), anyString())).thenReturn(true);
+
     newsService.deleteNews(draftPage.getId(), identity, NewsUtils.NewsObjectType.DRAFT.name().toLowerCase());
 
     // Then
@@ -594,8 +598,7 @@ public class NewsServiceImplTest {
       assertThrows(IllegalAccessException.class, () -> newsService.updateNews(news, "john", false, false, NewsUtils.NewsObjectType.DRAFT.name().toLowerCase(), CONTENT_AND_TITLE.name()));
 
     // Given
-    when(spaceService.canRedactOnSpace(space, identity)).thenReturn(true);
-    when(spaceService.isSuperManager(anyString())).thenReturn(true);
+    when(spaceService.isSuperManager(any(Space.class), anyString())).thenReturn(true);
     org.exoplatform.social.core.identity.model.Identity identity1 =
                                                                   mock(org.exoplatform.social.core.identity.model.Identity.class);
     when(identityManager.getOrCreateUserIdentity(anyString())).thenReturn(identity1);
@@ -677,8 +680,7 @@ public class NewsServiceImplTest {
     assertThrows(IllegalAccessException.class, () -> newsService.updateNews(news, "john", false, false, NewsUtils.NewsObjectType.DRAFT.name().toLowerCase(), CONTENT_AND_TITLE.name()));
 
     // Given
-    when(spaceService.canRedactOnSpace(space, identity)).thenReturn(true);
-    when(spaceService.isSuperManager(anyString())).thenReturn(true);
+    when(spaceService.isSuperManager(any(Space.class), anyString())).thenReturn(true);
     org.exoplatform.social.core.identity.model.Identity identity1 =
                                                                   mock(org.exoplatform.social.core.identity.model.Identity.class);
     when(identityManager.getOrCreateUserIdentity(anyString())).thenReturn(identity1);
@@ -753,8 +755,7 @@ public class NewsServiceImplTest {
     assertThrows(IllegalAccessException.class, () -> newsService.updateNews(news, "john", false, false, NewsUtils.NewsObjectType.DRAFT.name().toLowerCase(), CONTENT_AND_TITLE.name()));
 
     // Given
-    when(spaceService.canRedactOnSpace(space, identity)).thenReturn(true);
-    when(spaceService.isSuperManager(anyString())).thenReturn(true);
+    when(spaceService.isSuperManager(any(Space.class), anyString())).thenReturn(true);
     org.exoplatform.social.core.identity.model.Identity identity1 =
                                                                   mock(org.exoplatform.social.core.identity.model.Identity.class);
     when(identityManager.getOrCreateUserIdentity(anyString())).thenReturn(identity1);
@@ -806,7 +807,11 @@ public class NewsServiceImplTest {
     assertThrows(IllegalAccessException.class, () -> newsService.deleteNews(existingPage.getId(), identity, ARTICLE.name().toLowerCase()));
 
     // when
-    when(spaceService.canRedactOnSpace(space, identity)).thenReturn(true);
+    when(spaceService.isSuperManager(any(Space.class), anyString())).thenReturn(false);
+    when(spaceService.isRedactor(any(Space.class), anyString())).thenReturn(false);
+    when(spaceService.isManager(any(Space.class), anyString())).thenReturn(false);
+    when(spaceService.isMember(anyString(), anyString())).thenReturn(true);
+
     when(noteService.deleteNote(existingPage.getWikiType(), existingPage.getWikiOwner(), existingPage.getName())).thenReturn(true);
     DraftPage draftPage = mock(DraftPage.class);
     NotePageProperties draftProperties = new NotePageProperties();
@@ -1014,8 +1019,7 @@ public class NewsServiceImplTest {
     assertThrows(IllegalAccessException.class, () -> newsService.updateNews(news, "john", false, false, NewsUtils.NewsObjectType.DRAFT.name().toLowerCase(), CONTENT_AND_TITLE.name()));
 
     // Given
-    when(spaceService.canRedactOnSpace(space, identity)).thenReturn(true);
-    when(spaceService.isSuperManager(anyString())).thenReturn(true);
+    when(spaceService.isSuperManager(any(Space.class), anyString())).thenReturn(true);
     org.exoplatform.social.core.identity.model.Identity identity1 =
             mock(org.exoplatform.social.core.identity.model.Identity.class);
     when(identityManager.getOrCreateUserIdentity(anyString())).thenReturn(identity1);


### PR DESCRIPTION


Prior to this change, editing and deleting an article were based on the "can redact on space" API, which allowed members to redact in spaces that did not have a designated redactor. This logic caused an issue by allowing members to edit and delete articles they did not own.

To resolve this issue, we kept the article creation logic based on the "can redact" API but updated the logic for updating and deleting articles. Now, permissions for editing and deleting articles are handled separately, preventing users from updating or deleting articles they do not own, thus fixing the issue