### PR TITLE
Fix: Remove unneded removeNoteFeaturedImage operation when delete draft article and relay on draft deletion in notes Api - EXO-75508 - Meeds-io/meeds#2614

### DIFF
--- a/content-service/src/main/java/io/meeds/news/service/impl/NewsServiceImpl.java
+++ b/content-service/src/main/java/io/meeds/news/service/impl/NewsServiceImpl.java
@@ -1152,15 +1152,6 @@ public class NewsServiceImpl implements NewsService {
   public void deleteDraftArticle(String draftArticleId, String draftArticleCreator) throws Exception {
     DraftPage draftArticlePage = noteService.getDraftNoteById(draftArticleId, draftArticleCreator);
     if (draftArticlePage != null) {
-      if (draftArticlePage.getProperties() != null && draftArticlePage.getProperties().getFeaturedImage() != null) {
-        long featuredImageId = draftArticlePage.getProperties().getFeaturedImage().getId();
-        String userIdentityId = identityManager.getOrCreateUserIdentity(draftArticleCreator).getId();
-        noteService.removeNoteFeaturedImage(Long.parseLong(draftArticlePage.getId()),
-                                            featuredImageId,
-                                            null,
-                                            true,
-                                            Long.parseLong(userIdentityId));
-      }
       noteService.removeDraftById(draftArticlePage.getId());
       Space draftArticleSpace = spaceService.getSpaceByGroupId(draftArticlePage.getWikiOwner());
       MetadataObject draftArticleMetaDataObject =


### PR DESCRIPTION
Remove unneded removeNoteFeaturedImage operation when delete draft article and relay on draft deletion in notes Api which will handle correctly any case related to featured image deletion including when it comes from darft page.