### PR TITLE
fix: fix cancel article scheduling causes the lost of original properties - EXO-75716 - Meeds-io/meeds#2639

### DIFF
--- a/content-service/src/main/java/io/meeds/news/service/impl/NewsServiceImpl.java
+++ b/content-service/src/main/java/io/meeds/news/service/impl/NewsServiceImpl.java
@@ -783,6 +783,9 @@ public class NewsServiceImpl implements NewsService {
   public News unScheduleNews(News news, Space space, String articleCreator) throws Exception {
     News existingNews = getNewsArticleById(news.getId());
     if (existingNews != null && !existingNews.isFromExternalPage()) {
+      if (news.getProperties() != null) {
+        news.getProperties().setDraft(true);
+      }
       news = createDraftArticleForNewPage(news, space.getGroupId(), articleCreator, System.currentTimeMillis());
       deleteArticle(existingNews, articleCreator);
       return buildDraftArticle(news.getId(), articleCreator);

--- a/content-service/src/test/java/io/meeds/news/service/impl/NewsServiceImplTest.java
+++ b/content-service/src/test/java/io/meeds/news/service/impl/NewsServiceImplTest.java
@@ -972,6 +972,7 @@ public class NewsServiceImplTest {
     when(newsArticle.getId()).thenReturn("1");
     when(newsArticle.getBody()).thenReturn("body");
     when(newsArticle.getPublicationState()).thenReturn("staged");
+    when(newsArticle.getProperties()).thenReturn(new NotePageProperties());
     
     DraftPage draftPage = mock(DraftPage.class);
     when(draftPage.getUpdatedDate()).thenReturn(new Date());


### PR DESCRIPTION
Prior to this change, when cancel a scheduled article with properties and continue as draft, the new created draft doesnt conserve the original article properties because a wrong passed param in the properties object which doesn't indicate that the properties are belong to a draft. This PR fixes the issue by forcing to set the right needed param in the properties object when create a draft that comes from unschedule action