### PR TITLE
fix: Unable to publish on audience All - EXO-75814 - Meeds-io/MIPs#161

### DIFF
--- a/content-webapp/src/main/webapp/vue-app/news-activity-composer-app/components/ContentRichEditor.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-activity-composer-app/components/ContentRichEditor.vue
@@ -491,7 +491,7 @@ export default {
       this.article.published = publish;
       this.article.targets = selectedTargets;
       if (selectedAudience !== null) {
-        this.article.audience = selectedAudience === this.$t('news.composer.stepper.audienceSection.allUsers') ? 'all' : 'space';
+        this.article.audience = selectedAudience;
       }
       this.doPostArticle(schedulePostDate);
     },


### PR DESCRIPTION
Prior to this change, when publish an article on audience value a legacy check and value parsing causes an issue in the saved value to be always users. This PR ensures to set the right value sent from the new publication drawer while saving the article to fix the issue.