### PR TITLE
fix: fix cancel article scheduling causes the lost of original properties - EXO-75716 - Meeds-io/meeds#2639

### DIFF
--- a/content-service/src/main/java/io/meeds/news/service/impl/NewsServiceImpl.java
+++ b/content-service/src/main/java/io/meeds/news/service/impl/NewsServiceImpl.java
@@ -770,6 +770,9 @@ public class NewsServiceImpl implements NewsService {
   public News unScheduleNews(News news, String pageOwnerId, String articleCreator) throws Exception {
     News existingNews = getNewsArticleById(news.getId());
     if (existingNews != null) {
+      if (news.getProperties() != null) {
+        news.getProperties().setDraft(true);
+      }
       news = createDraftArticleForNewPage(news, pageOwnerId, articleCreator, System.currentTimeMillis());
       deleteArticle(existingNews, articleCreator);
       return buildDraftArticle(news.getId(), articleCreator);
@@ -2166,4 +2169,3 @@ public class NewsServiceImpl implements NewsService {
     NewsUtils.broadcastEvent(NewsUtils.UPDATE_CONTENT_PERMISSIONS, this, updateContentPermissionEventListenerData);
   }
 }
- 

--- a/content-service/src/test/java/io/meeds/news/service/impl/NewsServiceImplTest.java
+++ b/content-service/src/test/java/io/meeds/news/service/impl/NewsServiceImplTest.java
@@ -939,7 +939,8 @@ public class NewsServiceImplTest {
     News newsArticle = mock(News.class);
     when(newsArticle.getId()).thenReturn("1");
     when(newsArticle.getBody()).thenReturn("body");
-
+    when(newsArticle.getProperties()).thenReturn(new NotePageProperties());
+    
     DraftPage draftPage = mock(DraftPage.class);
     when(draftPage.getUpdatedDate()).thenReturn(new Date());
     when(draftPage.getCreatedDate()).thenReturn(new Date());


### PR DESCRIPTION
Prior to this change, when cancel a scheduled article with properties and continue as draft, the new created draft doesn't conserve the original article properties because a wrong passed param in the properties object which doesn't indicate that the properties are belong to a draft. 
This PR fixes the issue by forcing to set the right needed param in the properties object when create a draft that comes from unschedule action