### PR TITLE
Fix: Article draft not saved when adding an image to existing content- EXO-75826 - Meeds-io/Meeds#2649

### DIFF
--- a/content-webapp/src/main/webapp/vue-app/news-activity-composer-app/components/ContentRichEditor.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-activity-composer-app/components/ContentRichEditor.vue
@@ -145,9 +145,7 @@ export default {
       }
     },
     'article.content': function() {
-      if (!this.isSameArticleContent()) {
-        this.autoSave();
-      }
+      this.autoSave();
     },
     postingNews() {
       this.$refs.editor.setPublishing(this.postingNews);
@@ -187,7 +185,7 @@ export default {
                               && this.article.publicationState !== 'draft');
     },
     articleNotChanged() {
-      return this.originalArticle?.title === this.article.title && this.isSameArticleContent()
+      return this.originalArticle?.title === this.article.title && this.originalArticle?.content === this.article.content
                                                                 && !this.propertiesModified;
     },
     propertiesModified() {
@@ -820,9 +818,6 @@ export default {
       if (urlParams.has(paramName)) {
         return urlParams.get(paramName);
       }
-    },
-    isSameArticleContent() {
-      return this.$noteUtils.isSameContent(this.article.content, this.originalArticle.content);
     },
     refreshTranslationExtensions() {
       this.editorExtensions = extensionRegistry.loadExtensions('contentEditor', 'translation-extension');


### PR DESCRIPTION
Before this change, editing an article by adding an image to its content did not trigger the auto-save action. This issue occurred due to an incorrect comparison of the article content in the isSameContent method, which only compared the first level of HTML nodes. This change improves the content comparison logic, resolving the issue
