### PR TITLE
fix: Editing a draft of a published article removes the article from published articles list - EXO-75992 - Meeds-io/meeds#2694.

### DIFF
--- a/content-service/src/main/java/io/meeds/news/service/impl/NewsServiceImpl.java
+++ b/content-service/src/main/java/io/meeds/news/service/impl/NewsServiceImpl.java
@@ -1099,6 +1099,8 @@ public class NewsServiceImpl implements NewsService {
 
     Map<String, String> draftArticleMetadataItemProperties = new HashMap<>();
     draftArticleMetadataItemProperties.put(NEWS_ACTIVITY_POSTED, String.valueOf(draftArticle.isActivityPosted()));
+    draftArticleMetadataItemProperties.put(PUBLISHED, String.valueOf(draftArticle.isPublished()));
+
     setScheduleProperties(draftArticle, draftArticleMetadataItemProperties);
     String draftArticleMetadataItemCreatorIdentityId = identityManager.getOrCreateUserIdentity(updater).getId();
     metadataService.createMetadataItem(latestDraftObject,
@@ -1449,6 +1451,9 @@ public class NewsServiceImpl implements NewsService {
         }
         if (properties.containsKey(UNPUBLISH_SCHEDULED_DATE) && StringUtils.isNotEmpty(properties.get(UNPUBLISH_SCHEDULED_DATE))) {
           draftArticle.setScheduleUnpublishDate(properties.get(UNPUBLISH_SCHEDULED_DATE));
+        }
+        if (properties.containsKey(PUBLISHED) && StringUtils.isNotEmpty(properties.get(PUBLISHED))) {
+          draftArticle.setPublished(Boolean.valueOf(properties.get(PUBLISHED)));
         }
       }
     }


### PR DESCRIPTION
Before this change, after creating a draft the published data of the teargets will be false for news articles. To resolve this problem, when creating the draft, set the published value of this draft to the published value of the article if it already exists. After this change, the article is published under the adequete target.