### PR TITLE
fix: Editing a draft of a published article removes the article from published articles list - EXO-75992 - Meeds-io/meeds#2694.

### DIFF
--- a/content-webapp/src/main/webapp/vue-app/news-activity-composer-app/components/ContentRichEditor.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-activity-composer-app/components/ContentRichEditor.vue
@@ -326,6 +326,7 @@ export default {
         this.article.targetPageId = createdArticle.targetPageId;
         this.article.properties = createdArticle.properties;
         this.article.draftPage = true;
+        this.article.published = createdArticle.published;
         this.article.targetPageId = createdArticle.targetPageId;
         this.article.publicationState = createdArticle.publicationState;
         this.article.schedulePostDate = createdArticle.schedulePostDate;
@@ -391,7 +392,7 @@ export default {
         targetPageId: this.article.targetPageId,
         title: this.article.title,
         body: this.replaceImagesURLs(this.$noteUtils.getContentToSave(this.editorBodyInputRef, this.oembedMinWidth)),
-        published: this.article.published,
+        published: this.originalArticle.published,
         activityPosted: this.article.activityPosted,
         schedulePostDate: this.article.schedulePostDate,
         publicationState: this.article.publicationState,


### PR DESCRIPTION
Before this change, after creating a draft the published data of the teargets will be false for news articles. To resolve this problem, when creating the draft, set the published value of this draft to the published value of the article if it already exists. After this change, the article is published under the adequete target.