### PR TITLE
fix: URL having Anchor element isn't displaying as expected - EXO-73493 - Meeds-io/meeds#2665.

### DIFF
--- a/content-webapp/src/main/webapp/vue-app/news-details/components/ExoNewsDetails.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-details/components/ExoNewsDetails.vue
@@ -202,6 +202,16 @@ export default {
     this.$root.$on('move-page', this.moveArticlePage);
     this.bindTreeViewNavigationClickListener();
   },
+  mounted() {
+    const urlHash = window.location.hash;
+    if (urlHash) {
+      const elementId = urlHash.substring(1);
+      const targetElement = document.getElementById(elementId);
+      if (targetElement) {
+        targetElement.scrollIntoView({behavior: 'smooth'});
+      }
+    }
+  },
   methods: {
     moveArticlePage(page, newParentPage) {
       const previousParentPageId = page.parentPageId;


### PR DESCRIPTION
Before this change, on Activity stream, click on news URL having anchors, news displayed having comment drawer opened. To resolve this problem, in the mounted method of Vue add a function to scroll to the anchor. After this change, the news is displayed focusing on anchor without opening the comments.