### PR TITLE
fix: Author displayed on target even though author is set hidden in news publish - EXO-76191 - Meeds-io/meeds#2711.

### DIFF
--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsCardsViewItem.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsCardsViewItem.vue
@@ -130,7 +130,7 @@ export default {
       return this.item.publishDate && this.item.publishDate.time && new Date(this.item.publishDate.time);
     },
     showArticleAuthor() {
-      return this.selectedOption && this.selectedOption.showArticleAuthor;
+      return this.selectedOption && this.selectedOption.showArticleAuthor && this.item && !this.item.properties.hideAuthor;
     },
     showArticleDate() {
       return this.selectedOption && this.selectedOption.showArticleDate;

--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsSliderView.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsSliderView.vue
@@ -67,6 +67,7 @@
                 <news-slider-view-item
                   :author="item.author"
                   :author-display-name="item.authorDisplayName"
+                  :properties="item.properties"
                   :space-display-name="item.spaceDisplayName"
                   :space-url="item.spaceUrl"
                   :space-avatar-url="item.spaceAvatarUrl"

--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsSliderViewItem.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsSliderViewItem.vue
@@ -89,6 +89,10 @@ export default {
       type: String,
       default: ''
     },
+    properties: {
+      type: Object,
+      default: null
+    },
     spaceDisplayName: {
       type: String,
       default: ''
@@ -157,7 +161,7 @@ export default {
       return this.selectedOption && this.selectedOption.showArticleImage;
     },
     showArticleAuthor() {
-      return this.selectedOption && this.selectedOption.showArticleAuthor;
+      return this.selectedOption && this.selectedOption.showArticleAuthor && !this.properties.hideAuthor;
     },
     showArticleSpace() {
       return this.selectedOption && this.selectedOption.showArticleSpace;

--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsStoriesViewItem.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsStoriesViewItem.vue
@@ -107,7 +107,7 @@ export default {
       return this.item.publishDate && this.item.publishDate.time && new Date(this.item.publishDate.time);
     },
     showArticleAuthor() {
-      return this.selectedOption && this.selectedOption.showArticleAuthor;
+      return this.selectedOption && this.selectedOption.showArticleAuthor && this.item  && !this.item.properties.hideAuthor;
     },
     showArticleDate() {
       return this.selectedOption && this.selectedOption.showArticleDate;


### PR DESCRIPTION
Before this change, when create an article and publish it on target by setting author hidden and save, this article in target is displayed including the author. To resolve this problem, add in the check of showArticleAuthor a condition to check the value of display of the author in the settings. After this change, the author is displayed in the news template only if show author is true in the settings of the news template and in the publish news.