### PR TITLE
fix: Fix activity hidden after news article update - EXO-76137 - Meeds-io/meeds#2745

### DIFF
--- a/content-service/src/main/java/io/meeds/news/service/impl/NewsServiceImpl.java
+++ b/content-service/src/main/java/io/meeds/news/service/impl/NewsServiceImpl.java
@@ -331,7 +331,7 @@ public class NewsServiceImpl implements NewsService {
       indexingService.reindex(NewsIndexingServiceConnector.TYPE, String.valueOf(newsId));
     }
     if (!news.getPublicationState().isEmpty() && !DRAFT.equals(news.getPublicationState())) {
-      if (post != null) {
+      if (post != null && !CONTENT_AND_TITLE.name().equalsIgnoreCase(newsUpdateType)) {
         updateNewsActivity(news, post, originalNews.isActivityPosted());
       }
       NewsUtils.broadcastEvent(NewsUtils.UPDATE_NEWS, updater, news);

--- a/content-webapp/src/main/webapp/vue-app/news-activity-composer-app/components/ContentRichEditor.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-activity-composer-app/components/ContentRichEditor.vue
@@ -358,7 +358,7 @@ export default {
           this.autosaveProcessedFromEditorExtension = false;
         });
     },
-    updateAndPostArticle() {
+    updateAndPostArticle() {     
       this.postingNews = true;
       const updatedArticle = this.getArticleToBeUpdated();
       updatedArticle.publicationState = this.scheduled && 'staged' || 'posted';
@@ -393,7 +393,7 @@ export default {
         title: this.article.title,
         body: this.replaceImagesURLs(this.$noteUtils.getContentToSave(this.editorBodyInputRef, this.oembedMinWidth)),
         published: this.originalArticle.published,
-        activityPosted: this.article.activityPosted,
+        activityPosted: this.originalArticle.activityPosted,
         schedulePostDate: this.article.schedulePostDate,
         publicationState: this.article.publicationState,
         scheduleUnpublishDate: this.article.scheduleUnpublishDate,


### PR DESCRIPTION
Prior to this change, when editing the main fields or properties of an article which is posted in the feed, the related activity is hidden after the edit. After this commit, we ensure to send the original article activityPosted value with the edited article data model in order to conserve the same post in feed behavior after the article edition.

Resolves https://github.com/Meeds-io/meeds/issues/2745