### PR TITLE
fix: Delete scheduled article: article posted and it displays blank content -EXO-76143 -Meeds-io/meeds#2696

### DIFF
--- a/content-service/src/main/java/io/meeds/news/service/impl/NewsServiceImpl.java
+++ b/content-service/src/main/java/io/meeds/news/service/impl/NewsServiceImpl.java
@@ -368,7 +368,7 @@ public class NewsServiceImpl implements NewsService {
         String newsActivities = news.getActivities();
         Stream.of(newsActivities.split(";")).map(activity -> activity.split(":")[1]).forEach(activityManager::deleteActivity);
       }
-      MetadataObject newsMetadataObject = new MetadataObject(NewsUtils.NEWS_METADATA_OBJECT_TYPE, newsId);
+      MetadataObject newsMetadataObject = new MetadataObject(NEWS_METADATA_PAGE_OBJECT_TYPE, newsId);
       metadataService.deleteMetadataItemsByObject(newsMetadataObject);
       indexingService.unindex(NewsIndexingServiceConnector.TYPE, String.valueOf(news.getId()));
       List<String> articleLanguages = getArticleLanguages(newsId, false);


### PR DESCRIPTION
Before this commit, when a scheduled article is deleted, it's related activity is posted and it displays a blank content. 
This is due to that the metadata used to post the activity is not deleted because of wrong metadata type is the delete request. This fix chqnge the metadata type from "news" to "newsPage" to fix the problem.