### PR TITLE
fix: URL having Anchor element isn't displaying as expected - EXO-73493 - Meeds-io/meeds#2665

### DIFF
--- a/content-webapp/src/main/webapp/vue-app/news-details/components/ExoNewsDetails.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-details/components/ExoNewsDetails.vue
@@ -202,6 +202,16 @@ export default {
     this.$root.$on('move-page', this.moveArticlePage);
     this.bindTreeViewNavigationClickListener();
   },
+  mounted() {
+    const urlHash = window.location.hash;
+    if (urlHash) {
+      const elementId = urlHash.substring(1);
+      const targetElement = document.getElementById(elementId);
+      if (targetElement) {
+        targetElement.scrollIntoView({behavior: 'smooth'});
+      }
+    }
+  },
   methods: {
     moveArticlePage(page, newParentPage) {
       const previousParentPageId = page.parentPageId;


### PR DESCRIPTION
Before this change, on Activity stream, click on note URL having anchors, URL is cleaned (anchor element removed) and note is displayed. To resolve this problem, add the hash in the URL and scroll to the anchor. After this change, Url is persisted and the note displayed focusing on anchor

(cherry picked from commit 86f53941b26c6ba5f3e2f45c61cc988aa8e8ff62)