### PR TITLE
fix: Prevent articles from being indexed as notes - EXO-75010 - Meeds-io/meeds#2752 

### DIFF
--- a/content-service/src/main/java/io/meeds/news/service/impl/NewsServiceImpl.java
+++ b/content-service/src/main/java/io/meeds/news/service/impl/NewsServiceImpl.java
@@ -1036,7 +1036,7 @@ public class NewsServiceImpl implements NewsService {
       if (newsArticlePage.getProperties() == null) {
         newsArticlePage.setProperties(new NotePageProperties(Long.parseLong(draftNewsId), null, null, false, false, true));
       }
-      newsArticlePage = noteService.createNote(wiki, newsArticlesRootNotePage.getName(), newsArticlePage, poster);
+      newsArticlePage = noteService.createNote(wiki, newsArticlesRootNotePage.getName(), newsArticlePage, poster, false);
       if (newsArticlePage != null) {
         PageVersion pageVersion = noteService.getPublishedVersionByPageIdAndLang(Long.parseLong(newsArticlePage.getId()), null);
         // set properties
@@ -1676,7 +1676,7 @@ public class NewsServiceImpl implements NewsService {
       newsArticlesRootNotePage.setContent("");
       // inherit syntax from wiki
       newsArticlesRootNotePage.setSyntax(wiki.getPreferences().getWikiPreferencesSyntax().getDefaultSyntax());
-      return noteService.createNote(wiki, null, newsArticlesRootNotePage);
+      return noteService.createNote(wiki, null, newsArticlesRootNotePage, false);
     }
     return null;
   }
@@ -1910,7 +1910,7 @@ public class NewsServiceImpl implements NewsService {
       }
       existingPage.setProperties(news.getProperties());
       existingPage.setAttachmentObjectType(ArticlePageAttachmentPlugin.OBJECT_TYPE);
-      existingPage = noteService.updateNote(existingPage, PageUpdateType.EDIT_PAGE_CONTENT_AND_TITLE, updater);
+      existingPage = noteService.updateNote(existingPage, PageUpdateType.EDIT_PAGE_CONTENT_AND_TITLE, updater, false);
       news.setUpdateDate(existingPage.getUpdatedDate());
       news.setUpdater(existingPage.getAuthor());
       news.setLang(existingPage.getLang());
@@ -2219,7 +2219,7 @@ public class NewsServiceImpl implements NewsService {
     Page existingPage = noteService.getNoteById(newsId);
     if (existingPage != null) {
       existingPage.setAttachmentObjectType(ArticlePageAttachmentPlugin.OBJECT_TYPE);
-      existingPage = noteService.updateNote(existingPage, PageUpdateType.EDIT_PAGE_CONTENT_AND_TITLE, versionCreator);
+      existingPage = noteService.updateNote(existingPage, PageUpdateType.EDIT_PAGE_CONTENT_AND_TITLE, versionCreator, false);
       news.setPublicationState(POSTED);
       // update the metadata item
       MetadataItem metadataItem =

--- a/content-service/src/test/java/io/meeds/news/service/impl/NewsServiceImplTest.java
+++ b/content-service/src/test/java/io/meeds/news/service/impl/NewsServiceImplTest.java
@@ -533,7 +533,7 @@ public class NewsServiceImplTest {
 
     Page createdPage = mock(Page.class);
     when(createdPage.getId()).thenReturn("1");
-    when(noteService.createNote(wiki, rootPage.getName(), newsArticlePage, identity)).thenReturn(createdPage);
+    when(noteService.createNote(wiki, rootPage.getName(), newsArticlePage, identity, false)).thenReturn(createdPage);
     PageVersion pageVersion = mock(PageVersion.class);
     when(noteService.getPublishedVersionByPageIdAndLang(1L, null)).thenReturn(pageVersion);
     when(identityManager.getOrCreateUserIdentity(anyString())).thenReturn(new org.exoplatform.social.core.identity.model.Identity("1"));
@@ -542,7 +542,7 @@ public class NewsServiceImplTest {
     newsService.createNews(newsArticle, identity);
 
     // Then
-    verify(noteService, times(1)).createNote(wiki, rootPage.getName(), newsArticlePage, identity);
+    verify(noteService, times(1)).createNote(wiki, rootPage.getName(), newsArticlePage, identity, false);
     verify(noteService, times(1)).getPublishedVersionByPageIdAndLang(1L, null);
     verify(metadataService, atLeast(1)).createMetadataItem(any(MetadataObject.class),
                                                          any(MetadataKey.class),
@@ -558,7 +558,7 @@ public class NewsServiceImplTest {
     when(noteService.getNoteById(anyString())).thenReturn(note);
     clearInvocations(noteService, metadataService);
     newsService.createNews(newsArticle, identity);
-    verify(noteService, times(0)).createNote(wiki, rootPage.getName(), newsArticlePage, identity);
+    verify(noteService, times(0)).createNote(wiki, rootPage.getName(), newsArticlePage, identity, false);
     verify(noteService, times(1)).getPublishedVersionByPageIdAndLang(1L, null);
     verify(metadataService, atLeast(1)).createMetadataItem(any(MetadataObject.class),
             any(MetadataKey.class),
@@ -785,13 +785,13 @@ public class NewsServiceImplTest {
     when(identityManager.getOrCreateUserIdentity(anyString())).thenReturn(identity1);
     when(identity1.getId()).thenReturn("1");
 
-    when(noteService.updateNote(any(Page.class), any(), any())).thenReturn(existingPage);
+    when(noteService.updateNote(any(Page.class), any(), any(), anyBoolean())).thenReturn(existingPage);
 
     // When
     newsService.updateNews(news, "john", false, false, ARTICLE.name().toLowerCase(), CONTENT_AND_TITLE.name());
 
     // Then
-    verify(noteService, times(1)).updateNote(any(Page.class), any(), any());
+    verify(noteService, times(1)).updateNote(any(Page.class), any(), any(), anyBoolean());
     verify(noteService, times(1)).createVersionOfNote(existingPage, identity.getUserId());
     verify(noteService, times(2)).getPublishedVersionByPageIdAndLang(1L, null);
   }
@@ -907,7 +907,7 @@ public class NewsServiceImplTest {
     when(identity1.getId()).thenReturn("1");
 
     newsService.scheduleNews(newsArticle, identity, DRAFT);
-    verify(noteService, times(1)).createNote(any(Wiki.class), anyString(), any(Page.class), any(Identity.class));
+    verify(noteService, times(1)).createNote(any(Wiki.class), anyString(), any(Page.class), any(Identity.class), anyBoolean());
   }
 
   @Test
@@ -1070,12 +1070,12 @@ public class NewsServiceImplTest {
     when(identityManager.getOrCreateUserIdentity(anyString())).thenReturn(identity1);
     when(identity1.getId()).thenReturn("1");
 
-    when(noteService.updateNote(any(Page.class), any(), any())).thenReturn(existingPage);
+    when(noteService.updateNote(any(Page.class), any(), any(), anyBoolean())).thenReturn(existingPage);
     // When
     newsService.updateNews(news, "john", false, false, ARTICLE.name().toLowerCase(), CONTENT_AND_TITLE.name());
 
     // Then
-    verify(noteService, times(1)).updateNote(any(Page.class), any(), any());
+    verify(noteService, times(1)).updateNote(any(Page.class), any(), any(), anyBoolean());
     verify(noteService, times(1)).createVersionOfNote(existingPage, identity.getUserId());
     verify(noteService, times(2)).getPublishedVersionByPageIdAndLang(1L, null);
     NEWS_UTILS.verify(() -> NewsUtils.broadcastEvent(eq(NewsUtils.ADD_ARTICLE_TRANSLATION), anyObject(), anyObject()), times(1));


### PR DESCRIPTION

Prior to this change, article creation and update caused duplication of the indexing behavior, with articles being indexed as both articles and notes. This change prevents this behavior by adding a broadcast parameter