### PR TITLE
fix: Target news settings are displayed to everyone  - EXO-76743 -Meeds-io/meeds#2802

### DIFF
--- a/content-webapp/src/main/webapp/vue-app/services/newsServices.js
+++ b/content-webapp/src/main/webapp/vue-app/services/newsServices.js
@@ -266,9 +266,7 @@ export function canPublishNews(spaceId) {
       'Content-Type': 'application/json'
     },
     method: 'GET'
-  }).then((resp) => resp.json()).then(resp => {
-    return resp;
-  });
+  }).then((resp) => resp && resp.ok && resp.json());
 }
 
 export function deleteArticleTranslation(newsId, lang) {


### PR DESCRIPTION
Before this change, not authenticated users could see and open the settings of the news list on a public page. This is due to that the application don't handle the error response returned from the rest service since the user is not connected.
 After this commit, the setting is not displayed in case of not authenticated user by checking the response status of the rest service.