### PR TITLE
fix: Note page not unindexed when the article is dereferred - MEED-8290 - Meeds-io/meeds#2838

### DIFF
--- a/content-service/src/main/java/io/meeds/news/service/impl/NewsServiceImpl.java
+++ b/content-service/src/main/java/io/meeds/news/service/impl/NewsServiceImpl.java
@@ -71,6 +71,7 @@ import org.exoplatform.social.metadata.model.MetadataObject;
 import org.exoplatform.social.metadata.model.MetadataType;
 import org.exoplatform.social.notification.LinkProviderUtils;
 import org.exoplatform.wiki.WikiException;
+import org.exoplatform.wiki.jpa.search.WikiPageIndexingServiceConnector;
 import org.exoplatform.wiki.model.DraftPage;
 import org.exoplatform.wiki.model.Page;
 import org.exoplatform.wiki.model.PageVersion;
@@ -1278,6 +1279,7 @@ public class NewsServiceImpl implements NewsService {
     } else {
       properties.remove(PAGE_REFERRED);
       properties.remove(DE_REFER_PAGE_ID);
+      indexingService.unindex(WikiPageIndexingServiceConnector.TYPE, articlePage.getId());
     }
   }
 


### PR DESCRIPTION
Prior to this change, when an article is dereferred (remove from notes tree), the corresponding note still appear in unified search results. After this commit, we ensure to is unindex the note page of a dereferred article in order to not be displayed as unified search result.

Resolves https://github.com/Meeds-io/meeds/issues/2838