### PR TITLE
fix: Allow space members to see their scheduled articles - MEED-8291 - Meeds-io/meeds#2843

### DIFF
--- a/content-service/src/main/java/io/meeds/news/service/impl/NewsServiceImpl.java
+++ b/content-service/src/main/java/io/meeds/news/service/impl/NewsServiceImpl.java
@@ -816,8 +816,7 @@ public class NewsServiceImpl implements NewsService {
     boolean isArticleAuthor = article.getAuthor() != null && article.getAuthor().equals(currentIdentity.getUserId());
     boolean spaceMemberCanSchedule = (article.isFromExternalPage() || isArticleAuthor)
         && spaceService.isMember(space, currentIdentity.getUserId());
-    return spaceMemberCanSchedule || spaceService.isManager(space, currentIdentity.getUserId())
-        || spaceService.isRedactor(space, currentIdentity.getUserId())
+    return spaceMemberCanSchedule || spaceService.isRedactor(space, currentIdentity.getUserId())
         || NewsUtils.canPublishNews(space.getId(), currentIdentity);
   }
 
@@ -1546,7 +1545,7 @@ public class NewsServiceImpl implements NewsService {
     metadataFilter.setMetadataProperties(Map.of(NEWS_PUBLICATION_STATE, STAGED, NEWS_DELETED, "false"));
     metadataFilter.setCombinedMetadataProperties(Map.of(UNPUBLISH_SCHEDULED, "true", NEWS_DELETED, "false"));
     metadataFilter.setSortField(filter.getOrder());
-    metadataFilter.setMetadataSpaceIds(NewsUtils.getAllowedScheduledNewsSpacesIds(currentIdentity, filter.getSpaces()));
+    metadataFilter.setMetadataSpaceIds(NewsUtils.getMyFilteredSpacesIds(currentIdentity, filter.getSpaces()));
     return metadataService.getMetadataItemsByFilter(metadataFilter, filter.getOffset(), filter.getLimit())
                           .stream()
                           .map(article -> {
@@ -1557,10 +1556,16 @@ public class NewsServiceImpl implements NewsService {
                               return null;
                             }
                           })
-                          .filter(Objects::nonNull)
+                          .filter(article -> {
+                            if (article != null) {
+                              Space articleSpace = spaceService.getSpaceById(article.getSpaceId());
+                              return canScheduleNews(articleSpace, currentIdentity, article);
+                            }
+                            return false;
+                          })
                           .toList();
   }
-
+  
   private List<News> getMyPostedArticles(NewsFilter filter, Identity currentIdentity) throws Exception {
     MetadataFilter metadataFilter = new MetadataFilter();
     metadataFilter.setMetadataName(NEWS_METADATA_NAME);

--- a/content-service/src/main/java/io/meeds/news/utils/NewsUtils.java
+++ b/content-service/src/main/java/io/meeds/news/utils/NewsUtils.java
@@ -173,19 +173,6 @@ public class NewsUtils {
     }).map(space -> Long.valueOf(space.getId())).toList();
   }
 
-  public static List<Long> getAllowedScheduledNewsSpacesIds(org.exoplatform.services.security.Identity currentIdentity,
-                                                            List<String> filteredSpacesIds) throws Exception {
-    SpaceService spaceService = CommonsUtils.getService(SpaceService.class);
-    return getMySpaces(currentIdentity).stream().filter(space -> {
-      boolean allowed = (spaceService.isManager(space, currentIdentity.getUserId())
-          || spaceService.isRedactor(space, currentIdentity.getUserId()) || canPublishNews(space.getId(), currentIdentity));
-      if (!CollectionUtils.isEmpty(filteredSpacesIds)) {
-        return allowed && filteredSpacesIds.contains(space.getId());
-      }
-      return allowed;
-    }).map(space -> Long.valueOf(space.getId())).toList();
-  }
-
   public static boolean canPublishNews(String spaceId, org.exoplatform.services.security.Identity currentIdentity) {
     if (!StringUtils.isBlank(spaceId)) {
       SpaceService spaceService = CommonsUtils.getService(SpaceService.class);
@@ -315,5 +302,4 @@ public class NewsUtils {
     ListAccess<Space> memberSpacesListAccess = spaceService.getMemberSpaces(userIdentity.getUserId());
     return Arrays.asList(memberSpacesListAccess.load(0, memberSpacesListAccess.getSize()));
   }
-
 }

--- a/content-service/src/test/java/io/meeds/news/service/impl/NewsServiceImplTest.java
+++ b/content-service/src/test/java/io/meeds/news/service/impl/NewsServiceImplTest.java
@@ -345,7 +345,7 @@ public class NewsServiceImplTest {
     draftPage.setAuthor("john");
     draftPage.setWikiOwner("/space/groupId");
 
-    Space space = mockSpace();
+    mockSpace();
 
     when(noteService.getDraftNoteById(anyString(), anyString())).thenReturn(draftPage);
     MetadataItem metadataItem = mock(MetadataItem.class);
@@ -597,9 +597,9 @@ public class NewsServiceImplTest {
     when(pageVersion.getUpdatedDate()).thenReturn(new Date());
     when(pageVersion.getAuthorFullName()).thenReturn("full name");
 
-    Space space = mockSpace();
-
-    Identity identity = mockIdentity();
+    mockSpace();
+    mockIdentity();
+    
     NEWS_UTILS.when(() -> NewsUtils.canPublishNews(anyString(), any(Identity.class))).thenReturn(false);
     NEWS_UTILS.when(() -> NewsUtils.processMentions(anyString(), any())).thenReturn(new HashSet<>());
 
@@ -672,9 +672,9 @@ public class NewsServiceImplTest {
     Map<String, String> properties = new HashMap<>();
     when(metadataItem.getProperties()).thenReturn(properties);
 
-    Space space = mockSpace();
-
-    Identity identity = mockIdentity();
+    mockSpace();
+    mockIdentity();
+    
     NEWS_UTILS.when(() -> NewsUtils.canPublishNews(anyString(), any(Identity.class))).thenReturn(false);
     NEWS_UTILS.when(() -> NewsUtils.processMentions(anyString(), any())).thenReturn(new HashSet<>());
     when(newsTargetingService.getTargetsByNews(any(News.class))).thenReturn(null);
@@ -744,7 +744,7 @@ public class NewsServiceImplTest {
     Map<String, String> properties = new HashMap<>();
     when(metadataItem.getProperties()).thenReturn(properties);
 
-    Space space = mockSpace();
+    mockSpace();
 
     Identity identity = mockIdentity();
     NEWS_UTILS.when(() -> NewsUtils.canPublishNews(anyString(), any(Identity.class))).thenReturn(false);
@@ -814,7 +814,7 @@ public class NewsServiceImplTest {
     Map<String, String> properties = new HashMap<>();
     properties.put(NEWS_ACTIVITIES, "1:1;");
     when(metadataItem.getProperties()).thenReturn(properties);
-    Space space = mockSpace();
+    mockSpace();
     Identity identity = mockIdentity();
     when(identityManager.getOrCreateUserIdentity(anyString())).thenReturn(new org.exoplatform.social.core.identity.model.Identity("1"));
     NEWS_UTILS.when(() -> NewsUtils.canPublishNews(anyString(), any(Identity.class))).thenReturn(false);
@@ -873,6 +873,7 @@ public class NewsServiceImplTest {
   public void testScheduleNews() throws Exception {
     Space space = mockSpace();
     Identity identity = mockIdentity();
+    when(spaceService.isMember(space, identity.getUserId())).thenReturn(true);
     when(spaceService.isManager(space, identity.getUserId())).thenReturn(true);
     MetadataItem metadataItem = mock(MetadataItem.class);
     List<MetadataItem> metadataItems = new ArrayList<>();
@@ -929,7 +930,7 @@ public class NewsServiceImplTest {
     when(metadataItem2.getProperties()).thenReturn(properties2);
 
     mockBuildArticle(metadataItems);
-
+    when(spaceService.isMember(any(Space.class), anyString())).thenReturn(true);
 
     List<News> newsList = newsService.getNews(newsFilter, johnIdentity);
     assertNotNull(newsList);
@@ -1027,7 +1028,7 @@ public class NewsServiceImplTest {
     when(metadataItem.getProperties()).thenReturn(properties);
     mockBuildArticle(metadataItems);
 
-    Space space = mockSpace();
+    mockSpace();
 
     Identity identity = mockIdentity();
     NEWS_UTILS.when(() -> NewsUtils.canPublishNews(anyString(), any(Identity.class))).thenReturn(false);
@@ -1078,7 +1079,7 @@ public class NewsServiceImplTest {
     verify(noteService, times(1)).updateNote(any(Page.class), any(), any(), anyBoolean());
     verify(noteService, times(1)).createVersionOfNote(existingPage, identity.getUserId());
     verify(noteService, times(2)).getPublishedVersionByPageIdAndLang(1L, null);
-    NEWS_UTILS.verify(() -> NewsUtils.broadcastEvent(eq(NewsUtils.ADD_ARTICLE_TRANSLATION), anyObject(), anyObject()), times(1));
+    NEWS_UTILS.verify(() -> NewsUtils.broadcastEvent(eq(NewsUtils.ADD_ARTICLE_TRANSLATION), any(), any()), times(1));
   }
 
   private void mockBuildArticle(List<MetadataItem> metadataItems) throws WikiException {


### PR DESCRIPTION
Prior to this change, simple space members can not see their scheduled articles from news app due to a lack of permissions for scheduled articles news app filter. After this change, we ensure that any space member can see the schedule its own scheduled articles.

Resolves https://github.com/Meeds-io/meeds/issues/2843