### PR TITLE
fix: News Search item having # will not disply results as expected - EXO-76795 - Meeds-io/meeds#2845.

### DIFF
--- a/content-service/src/main/java/io/meeds/news/search/NewsSearchConnector.java
+++ b/content-service/src/main/java/io/meeds/news/search/NewsSearchConnector.java
@@ -206,7 +206,7 @@ public class NewsSearchConnector {
 
   private String buildTermQueryStatement(String term) {
     if (StringUtils.isBlank(term)) {
-      return term;
+      return "";
     }
     term = removeSpecialCharacters(term);
     return SEARCH_QUERY_TERM.replace("@term@", term);


### PR DESCRIPTION
Before this change, when go to news application and use the inserted #hashtag, error displayed on browser console and results aren't displaying the expected outcome. To resolve this problem, in the buildTermQueryStatement return empty string instead of null if the term is empty. After this change, articles having the #hashtag is displayed.