### PR TITLE
fix : Error when first openinig notes page - MEED-8346

### DIFF
--- a/content-service/src/main/java/io/meeds/news/service/impl/NewsServiceImpl.java
+++ b/content-service/src/main/java/io/meeds/news/service/impl/NewsServiceImpl.java
@@ -2034,7 +2034,11 @@ public class NewsServiceImpl implements NewsService {
                                                            articlePage.getId(),
                                                            null,
                                                            Long.parseLong(space.getId()));
-        MetadataItem metadataItem = metadataService.getMetadataItemsByMetadataAndObject(NEWS_METADATA_KEY, newsPageObject).getFirst();
+        List<MetadataItem> metadataItems = metadataService.getMetadataItemsByMetadataAndObject(NEWS_METADATA_KEY, newsPageObject);
+        MetadataItem metadataItem = null;
+        if (!metadataItems.isEmpty()) {
+          metadataItem = metadataItems.getFirst();
+        }
         buildArticleProperties(news, currentUsername, metadataItem);
         news.setDeleted(articlePage.isDeleted());
         news.setPublicationDate(articlePage.getCreatedDate());
@@ -2042,7 +2046,7 @@ public class NewsServiceImpl implements NewsService {
         processPageContent(pageVersion, news);
         news.setUpdaterFullName(pageVersion.getAuthorFullName());
         news.setLang(pageVersion.getLang());
-        news.setUpdateDate(new Date(metadataItem.getUpdatedDate()));
+        news.setUpdateDate(metadataItem != null ? new Date(metadataItem.getUpdatedDate()) : articlePage.getUpdatedDate());
         news.setProperties(pageVersion.getProperties());
         news.setUrl(NewsUtils.buildNewsArticleUrl(news, currentUsername));
         news.setLatestVersionId(pageVersion.getId());


### PR DESCRIPTION
Before this fix, when opening a note not published, there is 2 requests resulting in 404 error. This create also errors logs in server log.
This problem is due to the fact that, as the note is not published, there is no metadata associated. This issue ensure to take care of this case.

Resolves meeds-io/meeds#2868