### PR TITLE
fix: News app search item having # should display no results if item doesn't exist - MEED-8353 - Meeds-io/meeds#2890.

### DIFF
--- a/content-service/src/main/java/io/meeds/news/rest/NewsRest.java
+++ b/content-service/src/main/java/io/meeds/news/rest/NewsRest.java
@@ -495,8 +495,11 @@ public class NewsRest {
         if (text.indexOf("#") == 0) {
           String tagName = text.replace("#", "");
           List<TagName> tagNames = tagService.findTags(new TagFilter(tagName, 0), userIdentityId);
-          if (tagNames != null && !tagNames.isEmpty())
+          if (tagNames != null && !tagNames.isEmpty()) {
             newsFilter.setTagNames(tagNames.stream().map(e -> e.getName()).toList());
+          } else {
+            return ResponseEntity.ok(newsEntity);
+          }
         }
 
         Identity identity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, currentIdentity.getUserId());

--- a/content-webapp/src/main/webapp/vue-app/news/components/NewsApp.vue
+++ b/content-webapp/src/main/webapp/vue-app/news/components/NewsApp.vue
@@ -392,7 +392,10 @@ export default {
           window.history.pushState('', 'News', this.removeQueryParam('search'));
         }
         return this.$nextTick();
-      }).catch(() => this.loadingNews = false)
+      }).catch(() => {
+        this.loadingNews = false;
+        this.newsList = [];
+      })
         .finally(() => {
           this.loadingNews = false;
           this.initialized = true;


### PR DESCRIPTION
Before this change, when go to news application and use in serach a non-existent tag, error displayed on browser console and results aren't displaying the expected outcome of no results found. To resolve this problem, at NewsRest level by returning an empty list if the tagName is null. After this change, no result is displayed.