### PR TITLE
fix: Display article title in POST NEWS and PUBLISH NEWS mail notifications description - MEED-8359

### DIFF
--- a/content-service/src/main/resources/locale/portlet/news/News_en.properties
+++ b/content-service/src/main/resources/locale/portlet/news/News_en.properties
@@ -93,12 +93,14 @@ news.activity.notAuthorizedUser=To react to this article, you must be a member o
 news.activity.notAuthorizedUserForSpaceHidden=To react to this article, you must be a space member.
 news.activity.clickToShowDetail=Click here for more details
 
-news.notification.description={0} has posted  in the {2} space an article
+news.notification.description={0} has posted in the {2} space an article
 news.notification.description.mention.in.news=You have been mentioned in the article:
 news.notification.description.publish.news={0} has published an article
 news.notification.title=New article posted in {0}
 news.notification.title.mention.in.news=You have been mentioned in the article "{0}"
 news.notification.title.published.news=New article published
+news.mailNotification.description={0} has posted in the {2} space an article {1}
+news.mailNotification.description.publish.news={0} has published an article {1}
 Notification.label.SayHello=Hi
 news.notification.button.goToContent.label=Open the article
 news.notification.label.footer=To stop receiving messages like this, <a target="_blank" class="notification_settings_url" href="{0}">change your notification settings</a>.

--- a/content-webapp/src/main/webapp/WEB-INF/notification/templates/mail/postNewsNotificationPlugin.gtmpl
+++ b/content-webapp/src/main/webapp/WEB-INF/notification/templates/mail/postNewsNotificationPlugin.gtmpl
@@ -57,13 +57,13 @@
                                                         def notificationDescription = "";
                                                         switch(CONTEXT) {
                                                         case "POST NEWS":
-                                                            notificationDescription =  _ctx.appRes("news.notification.description",creator,CONTENT_TITLE,spaceName);
+                                                            notificationDescription =  _ctx.appRes("news.mailNotification.description",creator,CONTENT_TITLE,spaceName);
                                                             break;
                                                         case "MENTION IN NEWS":
                                                             notificationDescription =  _ctx.appRes("news.notification.description.mention.in.news",CONTENT_TITLE);
                                                             break;
                                                         case "PUBLISH NEWS":
-                                                            notificationDescription =  _ctx.appRes("news.notification.description.publish.news", CURRENT_USER, CONTENT_TITLE);
+                                                            notificationDescription =  _ctx.appRes("news.mailNotification.description.publish.news", CURRENT_USER, CONTENT_TITLE);
                                                             break;
                                                         default:
                                                             break;


### PR DESCRIPTION

Prior to this change, the article title is not display in POST NEWS and PUBLISH NEWS mail notifications description which makes its not clear for notified users. After this commit, we ensure to display the article title for this mail notification.