### PR TITLE
fix: Display article title in MENTION IN NEWS mail notification description - MEED-8357 - Meeds-io/meeds#2902

### DIFF
--- a/content-service/src/main/resources/locale/portlet/news/News_en.properties
+++ b/content-service/src/main/resources/locale/portlet/news/News_en.properties
@@ -99,6 +99,7 @@ news.notification.description.publish.news={0} has published an article
 news.notification.title=New article posted in {0}
 news.notification.title.mention.in.news=You have been mentioned in the article "{0}"
 news.notification.title.published.news=New article published
+news.mailNotification.description.mention.in.news=You have been mentioned in the article: {0}
 Notification.label.SayHello=Hi
 news.notification.button.goToContent.label=Open the article
 news.notification.label.footer=To stop receiving messages like this, <a target="_blank" class="notification_settings_url" href="{0}">change your notification settings</a>.

--- a/content-webapp/src/main/webapp/WEB-INF/notification/templates/mail/postNewsNotificationPlugin.gtmpl
+++ b/content-webapp/src/main/webapp/WEB-INF/notification/templates/mail/postNewsNotificationPlugin.gtmpl
@@ -60,7 +60,7 @@
                                                             notificationDescription =  _ctx.appRes("news.notification.description",creator,CONTENT_TITLE,spaceName);
                                                             break;
                                                         case "MENTION IN NEWS":
-                                                            notificationDescription =  _ctx.appRes("news.notification.description.mention.in.news",CONTENT_TITLE);
+                                                            notificationDescription =  _ctx.appRes("news.mailNotification.description.mention.in.news",CONTENT_TITLE);
                                                             break;
                                                         case "PUBLISH NEWS":
                                                             notificationDescription =  _ctx.appRes("news.notification.description.publish.news", CURRENT_USER, CONTENT_TITLE);


### PR DESCRIPTION

Prior to this change, the article title is not display in MENTION IN NEWS mail notification description which makes its not clear for notified users. After this commit, we ensure to display the article title for this mail notification.

Resolves https://github.com/Meeds-io/meeds/issues/2902