### PR TITLE
fix: Article attachments lost when cancel the scheduling - MEED-8390 - Meeds-io/meeds#2935

### DIFF
--- a/content-service/src/main/java/io/meeds/news/service/impl/NewsServiceImpl.java
+++ b/content-service/src/main/java/io/meeds/news/service/impl/NewsServiceImpl.java
@@ -30,7 +30,6 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.*;
 import java.util.regex.Matcher;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import io.meeds.news.model.*;
@@ -781,6 +780,7 @@ public class NewsServiceImpl implements NewsService {
         news.getProperties().setDraft(true);
       }
       news = createDraftArticleForNewPage(news, space.getGroupId(), articleCreator, System.currentTimeMillis());
+      broadcastUnScheduleArticleEvent(existingNews, news.getId());
       deleteArticle(existingNews, articleCreator);
       return buildDraftArticle(news.getId(), articleCreator);
     } else if (existingNews != null) {
@@ -2299,5 +2299,14 @@ public class NewsServiceImpl implements NewsService {
       updateContentPermissionEventListenerData.put(NEWS_AUDIENCE, article.getAudience());
     }
     NewsUtils.broadcastEvent(NewsUtils.UPDATE_CONTENT_PERMISSIONS, this, updateContentPermissionEventListenerData);
+  }
+  private void broadcastUnScheduleArticleEvent(News unscheduledArticle, String createdDraftId) {
+    String unscheduledPageVersionId = noteService.getPublishedVersionByPageIdAndLang(Long.parseLong(unscheduledArticle.getId()), unscheduledArticle.getLang()).getId();
+    if (unscheduledPageVersionId != null) {
+      Map<String, String> eventData = new HashMap();
+      eventData.put("draftPageId", createdDraftId);
+      eventData.put("unscheduledPageVersionId", unscheduledPageVersionId);
+      NewsUtils.broadcastEvent("note.draft.for.new.page.created", this, eventData);
+    }
   }
 }


### PR DESCRIPTION
Prior to this change, when canceling the scheduling of an article with attachments, the article's attachments were not linked to the newly created draft. This change ensures that the attachments from the deleted article are moved to the newly created draft