### PR TITLE
fix: Replace url occurences of "news/editor" navigation node by "news-editor" navigation node - MEED-8425

### DIFF
--- a/content-webapp/src/main/webapp/vue-app/news-details/components/ExoNewsDetails.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-details/components/ExoNewsDetails.vue
@@ -275,7 +275,7 @@ export default {
     },
     editLink() {
       const newsType = this.activityId || this.scheduled ? this.$newsConstants.newsObjectType.LATEST_DRAFT : this.newsType;
-      let editUrl = `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/news/editor?spaceId=${this.spaceId}&newsId=${this.newsId}&activityId=${this.activityId}&spaceName=${this.currentSpace.prettyName}&type=${newsType}`;
+      let editUrl = `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/news-editor?spaceId=${this.spaceId}&newsId=${this.newsId}&activityId=${this.activityId}&spaceName=${this.currentSpace.prettyName}&type=${newsType}`;
       if (this.news.lang) {
         editUrl = `${editUrl}&lang=${this.news.lang}`;
       }

--- a/content-webapp/src/main/webapp/vue-app/news-extensions/activity-stream-extensions/components/activity/ActivitySwitchToNews.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-extensions/activity-stream-extensions/components/activity/ActivitySwitchToNews.vue
@@ -66,7 +66,7 @@ export default {
   },
   computed: {
     link() {
-      const baseUrl = `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/news/editor`;
+      const baseUrl = `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/news-editor`;
       if (eXo.env.portal.spaceId) {
         return `${baseUrl}?spaceId=${eXo.env.portal.spaceId}&spaceName=${eXo.env.portal.spaceName}&type=draft`;
       }

--- a/content-webapp/src/main/webapp/vue-app/news-extensions/activity-stream-extensions/components/activity/ActivityWriteNewsComposer.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-extensions/activity-stream-extensions/components/activity/ActivityWriteNewsComposer.vue
@@ -90,7 +90,7 @@ export default {
   methods: {
     switchToNews() {
       if (!this.disableComposerButton) {
-        let url = `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/news/editor`;
+        let url = `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/news-editor`;
         if (eXo.env.portal.spaceId) {
           url += `?spaceId=${eXo.env.portal.spaceId}&spaceName=${eXo.env.portal.spaceName}&type=draft`;
         }

--- a/content-webapp/src/main/webapp/vue-app/news-extensions/activity-stream-extensions/components/activity/ActivityWriteNewsToolbarAction.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-extensions/activity-stream-extensions/components/activity/ActivityWriteNewsToolbarAction.vue
@@ -61,7 +61,7 @@ export default {
   },
   methods: {
     switchToNews() {
-      let url = `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/news/editor`;
+      let url = `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/news-editor`;
       if (eXo.env.portal.spaceId) {
         url += `?spaceId=${eXo.env.portal.spaceId}&spaceName=${eXo.env.portal.spaceName}&type=draft`;
       }

--- a/content-webapp/src/main/webapp/vue-app/news/components/NewsApp.vue
+++ b/content-webapp/src/main/webapp/vue-app/news/components/NewsApp.vue
@@ -283,7 +283,7 @@ export default {
       this.$refs.mobileActionMenu.close();
     },
     getEditUrl(news) {
-      let editUrl = `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/news/editor?newsId=${news.targetPageId || news.newsId}`;
+      let editUrl = `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/news-editor?newsId=${news.targetPageId || news.newsId}`;
       if (news.spaceId) {
         editUrl += `&spaceId=${news.spaceId}`;
       }
@@ -300,7 +300,7 @@ export default {
       return editUrl;
     },
     getDraftUrl(item) {
-      let draftUrl = `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/news/editor`;
+      let draftUrl = `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/news-editor`;
       draftUrl += `?newsId=${item.activityId && item.targetPageId || item.id}`;
       if (item.spaceId) {
         draftUrl += `&spaceId=${item.spaceId}`;


### PR DESCRIPTION

Prior to this change, "news/news-editor" navigation node of global site was not accessible to guests even if they are in related page access permissions since the parent navigation node "news" is not accessible to them. In order to allow guest to access to news editor, we have replaced the url occurences of "news/editor" navigation node by newly created navigation node "news-editor".