### PR TITLE
fix: User identified after a publication  - Meeds-io/meeds#8377

### DIFF
--- a/content-service/src/main/java/io/meeds/news/service/impl/NewsServiceImpl.java
+++ b/content-service/src/main/java/io/meeds/news/service/impl/NewsServiceImpl.java
@@ -1211,13 +1211,9 @@ public class NewsServiceImpl implements NewsService {
   }
 
   private void postProcessing(News news, String poster) throws Exception {
-    if (news.getAuthor() == null) {
-      news.setAuthor(poster);
-    }
-
+    news.setAuthor(poster);
     postNewsActivity(news);
     sendNotification(poster, news, NotificationConstants.NOTIFICATION_CONTEXT.POST_NEWS);
-
     if (news.isPublished()) {
       publishNews(news, poster);
     }
@@ -1902,8 +1898,12 @@ public class NewsServiceImpl implements NewsService {
     activity.setTemplateParams(templateParams);
     activity.setMetadataObjectId(news.getId());
     activity.setMetadataObjectType(NewsUtils.NEWS_METADATA_OBJECT_TYPE);
-
     activityManager.saveActivityNoReturn(spaceIdentity, activity);
+    String newsId = news.getTargetPageId() != null ? news.getTargetPageId() : news.getId();
+    Page existingPage = noteService.getNoteById(newsId);
+    if (existingPage != null) {
+      noteService.createVersionOfNote(existingPage,news.getAuthor());
+    }
     updateNewsActivities(activity.getId(), news);
   }
 


### PR DESCRIPTION
Before this change, when a user publish an article, the user identifies was the author/creator of the article not the one who published it, also a new version shoukd be created since publication must be considered as upadte.
 After this commit, the user who published the article is identified in the activity and a newversion is created for publication.