### PR TITLE
fix: Fix exceptions NullPointerException when create and edit snv - MEED-8389_MEED-8393 - Meeds-io/meeds#2748_Meeds-io/meeds#2756

### DIFF
--- a/content-service/src/main/java/io/meeds/news/listener/ExternalArticlePageListener.java
+++ b/content-service/src/main/java/io/meeds/news/listener/ExternalArticlePageListener.java
@@ -69,7 +69,7 @@ public class ExternalArticlePageListener extends Listener<Object, Page> {
   @Override
   public void onEvent(Event<Object, Page> event) throws Exception {
     Page page = event.getData();
-    if (page != null) {
+    if (page != null && !page.getOwner().equals("__system")) {
       if (event.getEventName().equals(NOTE_UPDATED)) {
         News news = newsService.getNewsArticleById(page.getId());
         if (news != null && news.getActivityId() != null) {

--- a/content-service/src/test/java/io/meeds/news/listener/ExternalArticlePageListenerTest.java
+++ b/content-service/src/test/java/io/meeds/news/listener/ExternalArticlePageListenerTest.java
@@ -57,6 +57,7 @@ public class ExternalArticlePageListenerTest {
     note.setId("1");
     note.setWikiOwner("/spaces/space");
     note.setContent("tes");
+    note.setOwner("root");
     Identity identity = mock(Identity.class);
 
     Event<Object, Page> event = new Event<>("note.updated", "user", note);


### PR DESCRIPTION

Prior to this change NullPointerException occurs when creating or updating an snv, this is due to the unneeded execution of ExternalArticlePageListener. After this change, we ensure to avoid execution of the listener in the case of snv.