### PR TITLE
fix: User identified after a publication  - Meeds-io/meeds#8377

### DIFF
--- a/content-service/src/main/java/io/meeds/news/service/impl/NewsServiceImpl.java
+++ b/content-service/src/main/java/io/meeds/news/service/impl/NewsServiceImpl.java
@@ -1710,7 +1710,7 @@ public class NewsServiceImpl implements NewsService {
     String activities = news.getActivities();
     String contentTitle = news.getTitle();
     String contentBody = news.getBody();
-    String lastSpaceIdActivityId = activities.split(";")[activities.split(";").length - 1];
+    String lastSpaceIdActivityId = StringUtils.deleteWhitespace(activities.split(";")[activities.split(";").length - 1]);
     String contentSpaceId = lastSpaceIdActivityId.split(":")[0];
     String contentActivityId = lastSpaceIdActivityId.split(":")[1];
     Space contentSpace = spaceService.getSpaceById(contentSpaceId);


### PR DESCRIPTION
Before this change, when a user publish an article, the user identifies was the author/creator of the article not the one who published it, also a new version shoukd be created since publication must be considered as upadte.
 After this commit, the user who published the article is identified in the activity and a newversion is created for publication.