### PR TITLE
fix: Fix space member can not edit/delete/publish his own article and can not see his own scheduled article when edited by another member - MEED-8449 - Meeds-io/meeds#2967

### DIFF
--- a/content-service/src/main/java/io/meeds/news/model/News.java
+++ b/content-service/src/main/java/io/meeds/news/model/News.java
@@ -50,6 +50,8 @@ public class News {
   private String                          originalBody;
 
   private String                          author;
+  
+  private String                          owner;
 
   private String                          authorDisplayName;
 

--- a/content-service/src/main/java/io/meeds/news/service/impl/NewsServiceImpl.java
+++ b/content-service/src/main/java/io/meeds/news/service/impl/NewsServiceImpl.java
@@ -813,8 +813,7 @@ public class NewsServiceImpl implements NewsService {
    */
   @Override
   public boolean canScheduleNews(Space space, Identity currentIdentity, News article) {
-    boolean isArticleAuthor = article.getAuthor() != null && article.getAuthor().equals(currentIdentity.getUserId());
-    boolean spaceMemberCanSchedule = (article.isFromExternalPage() || isArticleAuthor)
+    boolean spaceMemberCanSchedule = (article.isFromExternalPage() || isArticleOwner(article, currentIdentity.getUserId()))
         && spaceService.isMember(space, currentIdentity.getUserId());
     return spaceMemberCanSchedule || spaceService.isRedactor(space, currentIdentity.getUserId())
         || NewsUtils.canPublishNews(space.getId(), currentIdentity);
@@ -954,6 +953,7 @@ public class NewsServiceImpl implements NewsService {
       draftArticle.setProperties(draftArticlePage.getProperties());
       draftArticle.setIllustrationURL(NewsUtils.buildIllustrationUrl(draftArticle.getProperties(), draftArticlePage.getLang()));
       draftArticle.setId(draftArticlePage.getId());
+      draftArticle.setOwner(draftArticlePage.getOwner());
       draftArticle.setCreationDate(draftArticlePage.getCreatedDate());
       draftArticle.setUpdateDate(draftArticlePage.getUpdatedDate());
       draftArticle.setBody(draftArticlePage.getContent());
@@ -1647,17 +1647,13 @@ public class NewsServiceImpl implements NewsService {
   private boolean isArticleOwner(News article, String userName) {
     return StringUtils.isNotEmpty(article.getOwner()) && article.getOwner().equals(userName);
   }
-  
-  private boolean isArticleAuthor(News article, String userName) {
-    return StringUtils.isNotEmpty(article.getAuthor()) && article.getAuthor().equals(userName);
-  }
-  
+
   private boolean canDeleteNews(Identity currentIdentity, News news) {
     Space space = news.getSpaceId() == null ? null : spaceService.getSpaceById(news.getSpaceId());
     if (space == null) {
       return false;
     }
-    boolean isMemberCanDelete = isArticleAuthor(news, currentIdentity.getUserId())
+    boolean isMemberCanDelete = isArticleOwner(news, currentIdentity.getUserId())
         && spaceService.isMember(space.getId(), currentIdentity.getUserId());
     return isMemberCanDelete || NewsUtils.canPublishNews(news.getSpaceId(), currentIdentity)
         || (spaceService.isManager(space, currentIdentity.getUserId())

--- a/content-service/src/main/java/io/meeds/news/service/impl/NewsServiceImpl.java
+++ b/content-service/src/main/java/io/meeds/news/service/impl/NewsServiceImpl.java
@@ -1314,6 +1314,7 @@ public class NewsServiceImpl implements NewsService {
       draftArticle.setId(draftArticlePage.getId());
       draftArticle.setTitle(draftArticlePage.getTitle());
       draftArticle.setAuthor(draftArticlePage.getAuthor());
+      draftArticle.setOwner(draftArticlePage.getOwner());
       draftArticle.setCreationDate(draftArticlePage.getCreatedDate());
       draftArticle.setUpdateDate(draftArticlePage.getUpdatedDate());
       draftArticle.setDraftUpdateDate(draftArticlePage.getUpdatedDate());
@@ -1636,13 +1637,17 @@ public class NewsServiceImpl implements NewsService {
       LOG.warn("Can't find user with id {} when checking access on news with id {}", authenticatedUser, news.getId());
       return false;
     }
-    boolean isSpaceMemberCanEdit = isArticleAuthor(news, authenticatedUser) && spaceService.isMember(spaceId, authenticatedUser);
+    boolean isSpaceMemberCanEdit = spaceService.isMember(spaceId, authenticatedUser) && (news.isFromExternalPage() || isArticleOwner(news, authenticatedUser));
     return  isSpaceMemberCanEdit || NewsUtils.canPublishNews(news.getSpaceId(), authenticatedUserIdentity)
         || (spaceService.isManager(space, authenticatedUser)
             || spaceService.isSuperManager(space, authenticatedUser)
             || spaceService.isRedactor(space, authenticatedUser));
   }
-
+  
+  private boolean isArticleOwner(News article, String userName) {
+    return StringUtils.isNotEmpty(article.getOwner()) && article.getOwner().equals(userName);
+  }
+  
   private boolean isArticleAuthor(News article, String userName) {
     return StringUtils.isNotEmpty(article.getAuthor()) && article.getAuthor().equals(userName);
   }
@@ -2009,6 +2014,7 @@ public class NewsServiceImpl implements NewsService {
         news.setId(articlePage.getId());
         news.setCreationDate(articlePage.getCreatedDate());
         news.setAuthor(pageVersion.getAuthor());
+        news.setOwner(articlePage.getOwner());
         news.setUpdater(pageVersion.getAuthor());
         news.setSpaceId(space.getId());
         news.setSpaceAvatarUrl(space.getAvatarUrl());

--- a/content-service/src/test/java/io/meeds/news/service/impl/NewsServiceImplTest.java
+++ b/content-service/src/test/java/io/meeds/news/service/impl/NewsServiceImplTest.java
@@ -823,7 +823,7 @@ public class NewsServiceImplTest {
     PageVersion pageVersion = mock(PageVersion.class);
     when(noteService.getPublishedVersionByPageIdAndLang(1L, null)).thenReturn(pageVersion);
 
-    when(existingPage.getAuthor()).thenReturn("john");
+    when(existingPage.getOwner()).thenReturn("john");
     when(pageVersion.getAuthor()).thenReturn("john");
     when(pageVersion.getUpdatedDate()).thenReturn(new Date());
     when(pageVersion.getAuthorFullName()).thenReturn("full name");
@@ -893,7 +893,7 @@ public class NewsServiceImplTest {
             NEWS_ARTICLES_ROOT_NOTE_PAGE_NAME)).thenReturn(rootPage);
 
     News newsArticle = new News();
-    newsArticle.setAuthor("john");
+    newsArticle.setOwner("john");
     newsArticle.setTitle("news article");
     newsArticle.setBody("news body");
     newsArticle.setPublicationState("staged");
@@ -1088,7 +1088,7 @@ public class NewsServiceImplTest {
     page.setContent("article body");
     page.setTitle("article");
     page.setId("1");
-    page.setAuthor("john");
+    page.setOwner("john");
     page.setWikiOwner("/space/groupId");
     page.setName("article name");
     page.setWikiType("group");

--- a/content-webapp/src/main/webapp/vue-app/news-activity-composer-app/components/ContentRichEditor.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-activity-composer-app/components/ContentRichEditor.vue
@@ -425,6 +425,7 @@ export default {
               if (this.article.body !== updatedArticle.body) {
                 this.imagesURLs = this.extractImagesURLsDiffs(this.article.body, updatedArticle.body);
               }
+              this.article.owner = updatedArticle.owner;
               this.article.draftPage = true;
               this.article.id = updatedArticle.id;
               this.article.properties = updatedArticle?.properties;
@@ -451,6 +452,7 @@ export default {
         this.$newsServices.saveNews(article).then((createdArticle) => {
           this.draftSavingStatus = this.$t('news.composer.draft.savedDraftStatus');
           this.article.id = createdArticle.id;
+          this.article.owner = createdArticle.owner;
           this.article.draftPage = true;
           this.article.lang = createdArticle.lang;
           this.article.properties = createdArticle?.properties;
@@ -493,6 +495,7 @@ export default {
         title: this.article.title,
         body: this.replaceImagesURLs(this.$noteUtils.getContentToSave(this.editorBodyInputRef, this.oembedMinWidth)),
         author: this.currentUser,
+        owner: this.article.owner,
         published: this.article.published,
         targets: this.article.targets,
         spaceId: this.spaceId,

--- a/content-webapp/src/main/webapp/vue-app/news/components/NewsApp.vue
+++ b/content-webapp/src/main/webapp/vue-app/news/components/NewsApp.vue
@@ -311,7 +311,7 @@ export default {
       if (item.spaceUrl) {
         draftUrl += `&spaceName=${item.spaceUrl.substring(item.spaceUrl.lastIndexOf('/') + 1)}`;
       }
-      draftUrl += `&type=${item.activityId && 'latest_draft' || 'draft'}`;
+      draftUrl += `&type=${(item.activityId || item.schedulePostDate) && 'latest_draft' || 'draft'}`;
       return draftUrl;
     },
     getNewsText(newsSummary, newsBody) {


### PR DESCRIPTION
Prior to this change, a space member don't find the edit/delete/publish action buttons on his own article and can not see his own scheduled article when edited by another member. It is due to the wrong "article author" permission set for edit/delete and schedule cases.
After this change, we ensure to set the edit/delete/schedule permissions to article owners instead of article authors.

Resolves https://github.com/Meeds-io/meeds/issues/2967