### PR TITLE
fix: Indicate the edition of an article in the article details display - MEED-8488 - Meeds-io/meeds#2994

### DIFF
--- a/content-service/src/main/resources/locale/portlet/news/News_en.properties
+++ b/content-service/src/main/resources/locale/portlet/news/News_en.properties
@@ -284,6 +284,7 @@ content.alert.success.label.translation.deleted=Translation successfully deleted
 article.automatic.translation.label=Automatic translation
 article.label.translation.originalVersion=Original version
 article.label.chooseLanguage=Choose a language
+article.edited.by.label=Edited by
 
 content.article.refer.to.note=Refer in the Notes
 content.article.refer.label=Refer

--- a/content-service/src/main/resources/locale/portlet/news/News_fr.properties
+++ b/content-service/src/main/resources/locale/portlet/news/News_fr.properties
@@ -284,6 +284,7 @@ content.alert.success.label.translation.deleted=La traduction a été supprimée
 article.automatic.translation.label=Traduction automatique
 article.label.translation.originalVersion=Version originale
 article.label.chooseLanguage=Choisir une langue
+article.edited.by.label=�?dité par
 
 content.article.refer.to.note=Référencer dans les Notes
 content.article.refer.label=Référencer

--- a/content-service/src/main/resources/locale/portlet/news/News_fr.properties
+++ b/content-service/src/main/resources/locale/portlet/news/News_fr.properties
@@ -284,7 +284,7 @@ content.alert.success.label.translation.deleted=La traduction a été supprimée
 article.automatic.translation.label=Traduction automatique
 article.label.translation.originalVersion=Version originale
 article.label.chooseLanguage=Choisir une langue
-article.edited.by.label=�?dité par
+article.edited.by.label=\u00C9dit\u00E9 par
 
 content.article.refer.to.note=Référencer dans les Notes
 content.article.refer.label=Référencer

--- a/content-webapp/src/main/webapp/vue-app/news-details/components/ExoNewsDetailsBody.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-details/components/ExoNewsDetailsBody.vue
@@ -109,7 +109,7 @@
               <div
                 :class="{'mt-n2': !hiddenSpace}"
                 class="text-sub-title align-center d-flex">
-                <span v-if="isArticleEdited" class="ms-2">{{$t('article.edited.by.label')}}</span>
+                <span v-if="isArticleEdited" class="text-caption ms-2">{{$t('article.edited.by.label')}}</span>
                 <exo-user-avatar
                   :profile-id="articleUpdater"
                   extra-class="ms-2"

--- a/content-webapp/src/main/webapp/vue-app/news-details/components/ExoNewsDetailsBody.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-details/components/ExoNewsDetailsBody.vue
@@ -109,6 +109,7 @@
               <div
                 :class="{'mt-n2': !hiddenSpace}"
                 class="text-sub-title align-center d-flex">
+                <span v-if="isArticleEdited" class="ms-2">{{$t('article.edited.by.label')}}</span>
                 <exo-user-avatar
                   :profile-id="articleUpdater"
                   extra-class="ms-2"
@@ -198,6 +199,9 @@ export default {
     },
     isPublicAccess() {
       return !eXo?.env?.portal?.userIdentityId;
+    },
+    isArticleEdited() {
+      return this.news?.author !== this.news?.owner;
     },
     params() {
       return {


### PR DESCRIPTION
Prior to this change, after editing an article, the user displayed in the article details was the last modifier of the article without any indication. This change will add an indication of the article's edition in the article details