### PR TITLE
fix: Replace the delete option with the hide article activity option - MEED-8487 - Meeds-io/meeds#2872 (#410)

### DIFF
--- a/content-service/src/main/java/io/meeds/news/service/impl/NewsServiceImpl.java
+++ b/content-service/src/main/java/io/meeds/news/service/impl/NewsServiceImpl.java
@@ -1425,7 +1425,7 @@ public class NewsServiceImpl implements NewsService {
         article.setViewsCount(Long.parseLong(properties.get(NEWS_VIEWS)));
       }
       if (properties.containsKey(NEWS_ACTIVITY_POSTED)) {
-        article.setActivityPosted(Boolean.parseBoolean(properties.get(NEWS_ACTIVITY_POSTED)));
+        article.setActivityPosted(Boolean.parseBoolean(properties.get(NEWS_ACTIVITY_POSTED)) && !activityManager.getActivity(article.getActivityId()).isHidden());
       } else {
         article.setActivityPosted(false);
       }

--- a/content-webapp/src/main/webapp/vue-app/news-extensions/activity-stream-extensions/extensions.js
+++ b/content-webapp/src/main/webapp/vue-app/news-extensions/activity-stream-extensions/extensions.js
@@ -57,6 +57,8 @@ const newsActivityTypeExtensionOptions = {
   },
   canEdit: () => false,
   canShare: () => true,
+  canDelete: () => false,
+  canHide: () => true,
   hideOnDelete: true,
   supportsThumbnail: true,
   summaryLinesToDisplay: 2,


### PR DESCRIPTION
Prior to this change, deleting an article activity from the activity stream did not update the article activity post status in the publication drawer. This change replaces the delete article activity option with the hide option and ensures that the correct value is set for the activity post property.