### PR TITLE
fix: Fix publishing drawer displaying instead of edit publishing drawer after note publication - MEED-8507 - Meeds-io/meeds#3031

### DIFF
--- a/content-service/src/main/java/io/meeds/news/activity/processor/ActivityNewsProcessor.java
+++ b/content-service/src/main/java/io/meeds/news/activity/processor/ActivityNewsProcessor.java
@@ -87,12 +87,16 @@ public class ActivityNewsProcessor extends BaseActivityProcessorPlugin {
         }
         news = newsService.getNewsArticleById(activity.getTemplateParams().get("newsId"));
 
-        RealtimeListAccess<ExoSocialActivity> listAccess = activityManager.getCommentsWithListAccess(activity, true);
-        news.setCommentsCount(listAccess.getSize());
-        news.setLikesCount(activity.getLikeIdentityIds() == null ? 0 : activity.getLikeIdentityIds().length);
+        if (news != null) {
+          RealtimeListAccess<ExoSocialActivity> listAccess = activityManager.getCommentsWithListAccess(activity, true);
+          news.setCommentsCount(listAccess.getSize());
+          news.setLikesCount(activity.getLikeIdentityIds() == null ? 0 : activity.getLikeIdentityIds().length);
 
-        activity.setMetadataObjectId(news.getId());
-        activity.setMetadataObjectType(NewsUtils.NEWS_METADATA_OBJECT_TYPE);
+          activity.setMetadataObjectId(news.getId());
+          activity.setMetadataObjectType(NewsUtils.NEWS_METADATA_OBJECT_TYPE);
+        } else {
+          return;
+        }
       } catch (Exception e) {
         LOG.warn("Error retrieving news with id {}", activity.getTemplateParams().get("newsId"), e);
       }

--- a/content-service/src/main/java/io/meeds/news/rest/NewsRest.java
+++ b/content-service/src/main/java/io/meeds/news/rest/NewsRest.java
@@ -720,7 +720,9 @@ public class NewsRest {
       @ApiResponse(responseCode = "500", description = "Internal server error") })
   public ResponseEntity<Boolean> canScheduleNews(@PathVariable("spaceId") String spaceId,
                                                  @Parameter(description = "target article id")
-                                                 @RequestParam("articleId") String articleId) {
+                                                 @RequestParam("articleId") String articleId,
+                                                 @Parameter(description = "is external page to be scheduled")
+                                                 @RequestParam("fromExternalPage") boolean fromExternalPage) {
     org.exoplatform.services.security.Identity currentIdentity = ConversationState.getCurrent().getIdentity();
     try {
       if (StringUtils.isBlank(spaceId)) {
@@ -731,11 +733,11 @@ public class NewsRest {
         return ResponseEntity.notFound().build();
       }
       News news = newsService.getNewsArticleById(articleId);
-      if (news == null) {
+      if (news == null && !fromExternalPage) {
         return ResponseEntity.notFound().build();
       }
 
-      return ResponseEntity.ok(newsService.canScheduleNews(spaceId, currentIdentity, news));
+      return ResponseEntity.ok(fromExternalPage ? newsService.canScheduleExternalPageAsNews(articleId, currentIdentity) : newsService.canScheduleNews(spaceId, currentIdentity, news));
     } catch (Exception e) {
       LOG.error("Error when checking if the authenticated user can schedule a news", e);
       return ResponseEntity.internalServerError().build();

--- a/content-service/src/main/java/io/meeds/news/service/NewsService.java
+++ b/content-service/src/main/java/io/meeds/news/service/NewsService.java
@@ -293,6 +293,14 @@ public interface NewsService {
   boolean canScheduleNews(String spaceId, org.exoplatform.services.security.Identity currentIdentityId, News article);
 
   /**
+   * Checks if the user can schedule publishing a News
+   * @param articleId external article to be scheduled identifier
+   * @param currentIdentityId current user identity id
+   * @return boolean : true if the user can schedule publishing a News
+   */
+  boolean canScheduleExternalPageAsNews(String articleId , org.exoplatform.services.security.Identity currentIdentityId);
+
+  /**
    * Checks if the user can view the News
    *
    * @param news {@link News} to check

--- a/content-service/src/main/java/io/meeds/news/service/impl/NewsServiceImpl.java
+++ b/content-service/src/main/java/io/meeds/news/service/impl/NewsServiceImpl.java
@@ -556,7 +556,9 @@ public class NewsServiceImpl implements NewsService {
     News news = null;
     try {
       news = buildArticle(newsId, lang, true);
-      news.setTargets(newsTargetingService.getTargetsByNews(news));
+      if (news != null) {
+        news.setTargets(newsTargetingService.getTargetsByNews(news));
+      }
     } catch (Exception exception) {
       LOG.error("An error occurred while retrieving news with id {}", newsId, exception);
     }
@@ -863,6 +865,19 @@ public class NewsServiceImpl implements NewsService {
   public boolean canScheduleNews(String spaceId, Identity currentIdentity, News article) {
     return canEditNews(article, currentIdentity.getUserId())
         || NewsUtils.canPublishNews(spaceId, currentIdentity);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public boolean canScheduleExternalPageAsNews(String articleId, Identity currentIdentity) {
+    try {
+     Page pageToBeScheduled = noteService.getNoteById(articleId, currentIdentity);
+     return pageToBeScheduled != null && pageToBeScheduled.isCanManage();
+    } catch (Exception exception) {
+      return false;
+    }
   }
 
   /**
@@ -1451,7 +1466,11 @@ public class NewsServiceImpl implements NewsService {
         article.setViewsCount(Long.parseLong(properties.get(NEWS_VIEWS)));
       }
       if (properties.containsKey(NEWS_ACTIVITY_POSTED)) {
-        article.setActivityPosted(Boolean.parseBoolean(properties.get(NEWS_ACTIVITY_POSTED)) && !activityManager.getActivity(article.getActivityId()).isHidden());
+        ExoSocialActivity articleActivity = null;
+        if (article.getActivityId() != null) {
+          articleActivity = activityManager.getActivity(article.getActivityId());
+        }
+        article.setActivityPosted(Boolean.parseBoolean(properties.get(NEWS_ACTIVITY_POSTED)) && articleActivity != null && !articleActivity.isHidden());
       } else {
         article.setActivityPosted(false);
       }
@@ -2015,9 +2034,9 @@ public class NewsServiceImpl implements NewsService {
         News news = new News();
         news.setId(articlePage.getId());
         news.setCreationDate(articlePage.getCreatedDate());
-        news.setAuthor(pageVersion.getAuthor());
+        news.setAuthor(pageVersion != null ? pageVersion.getAuthor() : articlePage.getAuthor());
+        news.setUpdater(pageVersion != null ? pageVersion.getAuthor() : articlePage.getAuthor());
         news.setOwner(articlePage.getOwner());
-        news.setUpdater(pageVersion.getAuthor());
         news.setSpaceId(space.getId());
         news.setSpaceAvatarUrl(space.getAvatarUrl());
         news.setSpaceDisplayName(space.getDisplayName());
@@ -2043,10 +2062,10 @@ public class NewsServiceImpl implements NewsService {
                                                            null,
                                                            Long.parseLong(space.getId()));
         List<MetadataItem> metadataItems = metadataService.getMetadataItemsByMetadataAndObject(NEWS_METADATA_KEY, newsPageObject);
-        MetadataItem metadataItem = null;
-        if (!metadataItems.isEmpty()) {
-          metadataItem = metadataItems.getFirst();
+        if (metadataItems.isEmpty()) {
+          return null;
         }
+        MetadataItem metadataItem = metadataItems.getFirst();
         buildArticleProperties(news, currentUsername, metadataItem);
         news.setDeleted(articlePage.isDeleted());
         news.setPublicationDate(articlePage.getCreatedDate());

--- a/content-webapp/src/main/webapp/vue-app/news-details-app/components/ExoNewsDetailsApp.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-details-app/components/ExoNewsDetailsApp.vue
@@ -83,7 +83,7 @@ export default {
         this.news = null;
       }
       return this.$newsServices.getNewsById(id, false, 'article', lang).then((resp) => {
-        if (resp !== null && resp !== UNAUTHORIZED_CODE) {
+        if (!!resp && resp !== UNAUTHORIZED_CODE) {
           this.news = resp;
           this.showEditButton = this.news.canEdit;
           this.showPublishButton = this.news.canPublish || this.news?.canSchedule;

--- a/content-webapp/src/main/webapp/vue-app/news-extensions/note-publish-extensions/main.js
+++ b/content-webapp/src/main/webapp/vue-app/news-extensions/note-publish-extensions/main.js
@@ -64,7 +64,7 @@ function updateSavedPublicationSettings(noteId) {
 
 function extractNoteIdFromUrl() {
   const url = window.location.href;
-  const regex = /\/notes\/(\d+)$/;
+  const regex = /\/notes\/(\d+)(?:\?|$)/;
   const match = regex.exec(url);
   return match?.[1];
 }

--- a/content-webapp/src/main/webapp/vue-app/news-extensions/note-publish-extensions/publishService.js
+++ b/content-webapp/src/main/webapp/vue-app/news-extensions/note-publish-extensions/publishService.js
@@ -17,7 +17,7 @@ export function canPublish(spaceId) {
 }
 
 export function canSchedule(spaceId, articleId) {
-  return newsService.canScheduleNews(spaceId, articleId);
+  return newsService.canScheduleNews(spaceId, articleId, true);
 }
 
 export async function getSavedNotePublicationSettings(id, lang) {

--- a/content-webapp/src/main/webapp/vue-app/services/newsServices.js
+++ b/content-webapp/src/main/webapp/vue-app/services/newsServices.js
@@ -217,8 +217,8 @@ export function canUserCreateNews(spaceId) {
   }).then((resp) => resp && resp.ok && resp.json());
 }
 
-export function canScheduleNews(spaceId, articleId) {
-  return fetch(`${newsConstants.CONTENT_API}/contents/canScheduleNews/${eXo.env.portal.spaceId || spaceId}?articleId=${articleId}`, {
+export function canScheduleNews(spaceId, articleId, fromExternalPge) {
+  return fetch(`${newsConstants.CONTENT_API}/contents/canScheduleNews/${eXo.env.portal.spaceId || spaceId}?articleId=${articleId}&fromExternalPage=${fromExternalPge || false} `, {
     headers: {
       'Content-Type': 'application/json'
     },


### PR DESCRIPTION
Prior to this change, the publishing drawer was displayed instead of the edit publishing drawer after note publication. This issue was due to incorrect handling of getArticleById, which always returned an object even when no news article existed and only the note was present. Additionally, the "can schedule" api returned a "not found" response when attempting to schedule the publishing of a note as an article.

This change updates the news service layer to return null if no article exists and introduces a new method to check scheduling ability during the scheduling of note publishing.