### PR TITLE
fix: Fix error Logged when creating or updating articles - MEED-8489 - Meeds-io/meeds#2928

### DIFF
--- a/content-service/src/main/java/io/meeds/news/listener/NewsActivityListener.java
+++ b/content-service/src/main/java/io/meeds/news/listener/NewsActivityListener.java
@@ -19,6 +19,7 @@
  */
 package io.meeds.news.listener;
 
+import io.meeds.news.model.NewsPageObject;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.services.security.ConversationState;
@@ -34,11 +35,20 @@ import org.exoplatform.social.core.space.spi.SpaceService;
 import io.meeds.news.model.News;
 import io.meeds.news.service.NewsService;
 import io.meeds.news.utils.NewsUtils;
+import org.exoplatform.social.metadata.MetadataService;
+import org.exoplatform.social.metadata.model.MetadataItem;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import jakarta.annotation.PostConstruct;
 import org.springframework.stereotype.Component;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static io.meeds.news.service.impl.NewsServiceImpl.NEWS_ACTIVITY_POSTED;
+import static io.meeds.news.service.impl.NewsServiceImpl.NEWS_METADATA_KEY;
+import static io.meeds.news.service.impl.NewsServiceImpl.NEWS_METADATA_PAGE_OBJECT_TYPE;
 import static io.meeds.news.utils.NewsUtils.NewsObjectType.ARTICLE;
 
 /**
@@ -53,6 +63,8 @@ public class NewsActivityListener extends ActivityListenerPlugin {
 
   private static final String NEWS_ID = "newsId";
 
+  private static final String NEWS_ACTIVITY_TYPE = "news";
+
   @Autowired
   private ActivityManager     activityManager;
 
@@ -64,6 +76,9 @@ public class NewsActivityListener extends ActivityListenerPlugin {
 
   @Autowired
   private NewsService         newsService;
+
+  @Autowired
+  private MetadataService     metadataService;
 
   @PostConstruct
   public void init() {
@@ -122,6 +137,15 @@ public class NewsActivityListener extends ActivityListenerPlugin {
     }
   }
 
+  @Override
+  public void hideActivity(ActivityLifeCycleEvent event) {
+    ExoSocialActivity activity = event.getActivity();
+    if (activity != null && activity.getType().equals(NEWS_ACTIVITY_TYPE) && activity.getTemplateParams() != null
+        && activity.getTemplateParams().containsKey(NEWS_ID)) {
+      updateNewsPageMetadataObjectItem(activity);
+    }
+  }
+
   private Identity getIdentity(ExoSocialActivity sharedActivity) {
     String posterIdentityId = sharedActivity.getPosterId();
     return identityManager.getIdentity(posterIdentityId);
@@ -130,6 +154,32 @@ public class NewsActivityListener extends ActivityListenerPlugin {
   private Space getSpace(ExoSocialActivity sharedActivity) {
     String spacePrettyName = sharedActivity.getActivityStream().getPrettyId();
     return spaceService.getSpaceByPrettyName(spacePrettyName);
+  }
+
+  private String getCurrentIdentityId() {
+    org.exoplatform.services.security.Identity currentIdentity = ConversationState.getCurrent().getIdentity();
+    return identityManager.getOrCreateUserIdentity(currentIdentity.getUserId()).getId();
+  }
+
+  private void updateNewsPageMetadataObjectItem(ExoSocialActivity activity) {
+    String newsId = activity.getTemplateParams().get(NEWS_ID);
+    String spaceId = activity.getSpaceId();
+    String currentIdentityId = getCurrentIdentityId();
+    NewsPageObject newsPageObject = new NewsPageObject(NEWS_METADATA_PAGE_OBJECT_TYPE, newsId, null, Long.parseLong(spaceId));
+    MetadataItem metadataItem = metadataService.getMetadataItemsByMetadataAndObject(NEWS_METADATA_KEY, newsPageObject)
+                                               .stream()
+                                               .findFirst()
+                                               .orElse(null);
+    if (metadataItem != null) {
+      Map<String, String> properties = metadataItem.getProperties();
+      // update the property only when it is present and has a wrong value
+      // hide from the activity stream case
+      if (properties.containsKey(NEWS_ACTIVITY_POSTED) && properties.get(NEWS_ACTIVITY_POSTED) != null && Boolean.parseBoolean(properties.get(NEWS_ACTIVITY_POSTED))) {
+        properties.put(NEWS_ACTIVITY_POSTED, String.valueOf(false));
+        metadataItem.setProperties(properties);
+        metadataService.updateMetadataItem(metadataItem, Long.parseLong(currentIdentityId), false);
+      }
+    }
   }
 
 }

--- a/content-service/src/main/java/io/meeds/news/service/impl/NewsServiceImpl.java
+++ b/content-service/src/main/java/io/meeds/news/service/impl/NewsServiceImpl.java
@@ -1466,11 +1466,7 @@ public class NewsServiceImpl implements NewsService {
         article.setViewsCount(Long.parseLong(properties.get(NEWS_VIEWS)));
       }
       if (properties.containsKey(NEWS_ACTIVITY_POSTED)) {
-        ExoSocialActivity articleActivity = null;
-        if (article.getActivityId() != null) {
-          articleActivity = activityManager.getActivity(article.getActivityId());
-        }
-        article.setActivityPosted(Boolean.parseBoolean(properties.get(NEWS_ACTIVITY_POSTED)) && articleActivity != null && !articleActivity.isHidden());
+        article.setActivityPosted(Boolean.parseBoolean(properties.get(NEWS_ACTIVITY_POSTED)));
       } else {
         article.setActivityPosted(false);
       }

--- a/content-service/src/test/java/io/meeds/news/listener/NewsActivityListenerTest.java
+++ b/content-service/src/test/java/io/meeds/news/listener/NewsActivityListenerTest.java
@@ -20,6 +20,10 @@
 package io.meeds.news.listener;
 
 import static io.meeds.news.utils.NewsUtils.NewsObjectType.ARTICLE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
@@ -29,8 +33,15 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
+import org.exoplatform.social.metadata.MetadataService;
+import org.exoplatform.social.metadata.model.MetadataItem;
+import org.exoplatform.social.metadata.model.MetadataKey;
+import org.exoplatform.social.metadata.model.MetadataObject;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -66,6 +77,9 @@ public class NewsActivityListenerTest {
 
   @Mock
   private NewsService     newsService;
+
+  @Mock
+  private MetadataService metadataService;
 
   @InjectMocks
   NewsActivityListener    newsActivityListener;
@@ -210,4 +224,33 @@ public class NewsActivityListenerTest {
     verify(newsService, times(1)).getNewsById(newsId, currentIdentity, false, ARTICLE.name().toLowerCase());
     verify(newsService, times(1)).shareNews(eq(news), nullable(Space.class), nullable(Identity.class), nullable(String.class));
   }
+
+  @Test
+  public void testHideActivity_ShouldUpdateMetadata() {
+    ExoSocialActivity activity = mock(ExoSocialActivity.class);
+    ActivityLifeCycleEvent event = mock(ActivityLifeCycleEvent.class);
+    when(event.getActivity()).thenReturn(activity);
+    when(activity.getType()).thenReturn("news");
+    when(activity.getTemplateParams()).thenReturn(Map.of("newsId", "123"));
+    when(activity.getSpaceId()).thenReturn("1");
+
+    org.exoplatform.services.security.Identity currentIdentity = new org.exoplatform.services.security.Identity("john");
+    ConversationState.setCurrent(new ConversationState(currentIdentity));
+    when(identityManager.getOrCreateUserIdentity(anyString())).thenReturn(new Identity("1"));
+
+    MetadataItem metadataItem = mock(MetadataItem.class);
+    Map<String, String> metadataItemProperties = new HashMap<>();
+    metadataItemProperties.put("activityPosted", "true");
+    when(metadataItem.getProperties()).thenReturn(metadataItemProperties);
+    List<MetadataItem> metadataItems = new ArrayList<>();
+    metadataItems.add(metadataItem);
+    when(metadataService.getMetadataItemsByMetadataAndObject(any(MetadataKey.class),
+                                                             any(MetadataObject.class))).thenReturn(metadataItems);
+
+    newsActivityListener.hideActivity(event);
+
+    verify(metadataService, times(1)).updateMetadataItem(any(MetadataItem.class), anyLong(), anyBoolean());
+
+  }
+
 }


### PR DESCRIPTION
Prior to this change, building article properties used a combination of the stored `activityPosted` metadata property and the `isHidden` activity property to set the `isActivityPosted` article attribute. This combination was used to resolve the issue of binding this attribute (isActivityPosted) when the article activity was hidden from the activity stream. As a result, a IllegalStateException exception ("Reentrancy detected") was thrown due to multiple calls to the `getActivity` method.

This change updates the `activityPosted` metadata item property when hiding the activity from the activity stream, removes the use of the `getActivity` method, and resolves the issue.