### PR TITLE
fix: User identified after a publication  - Meeds-io/meeds#8377

### DIFF
--- a/content-service/src/main/java/io/meeds/news/service/impl/NewsServiceImpl.java
+++ b/content-service/src/main/java/io/meeds/news/service/impl/NewsServiceImpl.java
@@ -357,6 +357,9 @@ public class NewsServiceImpl implements NewsService {
       }
       NewsUtils.broadcastEvent(NewsUtils.UPDATE_NEWS, updater, news);
     }
+    if(newsUpdateType.equals(NewsUtils.NewsUpdateType.POSTING_AND_PUBLISHING.name())){
+      addNewArticleVersionWithLang(news, updaterIdentity, space);
+    }
     return news;
   }
 


### PR DESCRIPTION
Before this change, when a user publish an article, the user identifies was the author/creator of the article not the one who published it, also a new version should be created since publication must be considered as update.
 After this commit, the user who published the article is identified in the activity and a new version is created for publication and publication edit.