### PR TITLE
fix: Add schedule end date for post in feed - MEED-8533 - Meeds-io/meeds#3037 (#420)

### DIFF
--- a/content-service/src/main/java/io/meeds/news/job/PostScheduledNewsArticleJob.java
+++ b/content-service/src/main/java/io/meeds/news/job/PostScheduledNewsArticleJob.java
@@ -23,6 +23,8 @@ import io.meeds.common.ContainerTransactional;
 import io.meeds.news.model.News;
 import io.meeds.news.service.NewsService;
 import org.apache.commons.collections4.MapUtils;
+import org.exoplatform.social.core.activity.model.ExoSocialActivity;
+import org.exoplatform.social.core.manager.ActivityManager;
 import org.exoplatform.social.metadata.MetadataService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,6 +50,9 @@ public class PostScheduledNewsArticleJob {
 
   @Autowired
   private MetadataService     metadataService;
+
+  @Autowired
+  private ActivityManager     activityManager;
 
 
   @Scheduled(cron = "${meeds.content.postScheduledNewsArticle.job.cron:15 */2 * * * ?}")
@@ -115,7 +120,7 @@ public class PostScheduledNewsArticleJob {
                    .forEach(article -> {
                      if (article != null) {
                        try {
-                         newsService.unpublishNews(article.getId(), article.getAuthor());
+                         unpublishArticle(article);
                          LOG.info("Unpublish schedule executed articleId: {}, articleTitle: {}",
                                   article.getId(),
                                   article.getTitle());
@@ -140,5 +145,14 @@ public class PostScheduledNewsArticleJob {
 
     Calendar now = Calendar.getInstance();
     return schedulePostDate.before(now) || now.equals(schedulePostDate);
+  }
+  private void unpublishArticle(News article) throws Exception {
+    newsService.unpublishNews(article.getId(), article.getAuthor(), true);
+    if (article.isActivityPosted() && article.getActivityId() != null) {
+      ExoSocialActivity activity = activityManager.getActivity(article.getActivityId());
+      if (activity != null) {
+        activityManager.hideActivity(activity.getId());
+      }
+    }
   }
 }

--- a/content-service/src/main/java/io/meeds/news/service/NewsService.java
+++ b/content-service/src/main/java/io/meeds/news/service/NewsService.java
@@ -115,7 +115,7 @@ public interface NewsService {
    * @param publisher the publisher of the News
    * @throws Exception when an error occurs
    */
-  void unpublishNews(String newsId, String publisher) throws Exception;
+  void unpublishNews(String newsId, String publisher, boolean unpublishScheduled) throws Exception;
 
   /**
    * Retrieves a news identified by its technical identifier

--- a/content-service/src/main/java/io/meeds/news/service/impl/NewsServiceImpl.java
+++ b/content-service/src/main/java/io/meeds/news/service/impl/NewsServiceImpl.java
@@ -296,7 +296,7 @@ public class NewsServiceImpl implements NewsService {
       if (news.isPublished()) {
         publishNews(news, updater);
       } else {
-        unpublishNews(newsId, updater);
+        unpublishNews(newsId, updater, false);
       }
     }
     if (publish == news.isPublished() && news.isPublished() && canPublish) {
@@ -429,7 +429,7 @@ public class NewsServiceImpl implements NewsService {
    * {@inheritDoc}
    */
   @Override
-  public void unpublishNews(String newsId, String publisher) throws Exception {
+  public void unpublishNews(String newsId, String publisher, boolean unpublishScheduled) throws Exception {
     News news = getNewsArticleById(newsId);
     Space space = spaceService.getSpaceById(news.getSpaceId());
     newsTargetingService.deleteNewsTargets(news, publisher);
@@ -447,9 +447,11 @@ public class NewsServiceImpl implements NewsService {
       Map<String, String> properties = newsMetadataItem.getProperties();
       if (properties != null) {
         properties.put(PUBLISHED, String.valueOf(false));
-        properties.put(UNPUBLISH_SCHEDULED, "false");
-        properties.remove(UNPUBLISH_SCHEDULED_DATE);
         properties.remove(NEWS_AUDIENCE);
+        if (unpublishScheduled) {
+          properties.put(UNPUBLISH_SCHEDULED, "false");
+          properties.remove(UNPUBLISH_SCHEDULED_DATE);
+        }
       }
       newsMetadataItem.setProperties(properties);
       Date updatedDate = Calendar.getInstance().getTime();
@@ -760,7 +762,7 @@ public class NewsServiceImpl implements NewsService {
         if (news.isPublished()) {
           publishNews(news, currentIdentity.getUserId());
         } else {
-          unpublishNews(news.getId(), currentIdentity.getUserId());
+          unpublishNews(news.getId(), currentIdentity.getUserId(), false);
         }
       }
       // set the url and the space url to the scheduled news


### PR DESCRIPTION

Prior to this change, there was no scheduled end date for an article or posts in the feed. This change will add a scheduled end date for posts in the feed