### PR TITLE
fix: User identified after a publication  - Meeds-io/meeds#8377

### DIFF
--- a/content-service/src/main/java/io/meeds/news/service/impl/NewsServiceImpl.java
+++ b/content-service/src/main/java/io/meeds/news/service/impl/NewsServiceImpl.java
@@ -353,6 +353,9 @@ public class NewsServiceImpl implements NewsService {
       NewsUtils.broadcastEvent(NewsUtils.UPDATE_NEWS, updater, news);
       NewsUtils.broadcastEvent(NewsUtils.UPDATE_PUBLISH_CONTENT, updater, new ContentPublishEvent(originalNews, news));
     }
+    if(newsUpdateType.equals(NewsUtils.NewsUpdateType.POSTING_AND_PUBLISHING.name())){
+      addNewArticleVersionWithLang(news, updaterIdentity, space);
+    }
     return news;
   }
 
@@ -1259,10 +1262,7 @@ public class NewsServiceImpl implements NewsService {
   }
 
   private void postProcessing(News news, String poster) throws Exception {
-    if (news.getAuthor() == null) {
-      news.setAuthor(poster);
-    }
-
+    news.setAuthor(poster);
     postNewsActivity(news);
     sendNotification(poster, news, NotificationConstants.NOTIFICATION_CONTEXT.POST_NEWS);
 
@@ -1741,7 +1741,7 @@ public class NewsServiceImpl implements NewsService {
     String activities = news.getActivities();
     String contentTitle = news.getTitle();
     String contentBody = news.getBody();
-    String lastSpaceIdActivityId = activities.split(";")[activities.split(";").length - 1];
+    String lastSpaceIdActivityId = StringUtils.deleteWhitespace(activities.split(";")[activities.split(";").length - 1]);
     String contentSpaceId = lastSpaceIdActivityId.split(":")[0];
     String contentActivityId = lastSpaceIdActivityId.split(":")[1];
     Space contentSpace = spaceService.getSpaceById(contentSpaceId);
@@ -1932,6 +1932,11 @@ public class NewsServiceImpl implements NewsService {
     activity.setMetadataObjectType(NewsUtils.NEWS_METADATA_OBJECT_TYPE);
 
     activityManager.saveActivityNoReturn(spaceIdentity, activity);
+    String newsId = news.getTargetPageId() != null ? news.getTargetPageId() : news.getId();
+    Page existingPage = noteService.getNoteById(newsId);
+    if (existingPage != null) {
+      noteService.createVersionOfNote(existingPage,news.getAuthor());
+    }
     updateNewsActivities(activity.getId(), news);
   }
 
@@ -2301,8 +2306,10 @@ public class NewsServiceImpl implements NewsService {
         deleteDraftArticle(draftPage.getId(), draftPage.getAuthor());
       }
       NewsUtils.broadcastEvent(NewsUtils.ADD_ARTICLE_TRANSLATION, versionCreator.getUserId(), news);
-      String newsTranslationId = news.getId().concat("-").concat(news.getLang());
-      indexingService.index(NewsIndexingServiceConnector.TYPE, newsTranslationId);
+      if (StringUtils.isNotEmpty(news.getLang())) {
+        String newsTranslationId = news.getId().concat("-").concat(news.getLang());
+        indexingService.index(NewsIndexingServiceConnector.TYPE, newsTranslationId);
+      }
       updateArticlePermissions(List.of(space), news);
       return news;
     }


### PR DESCRIPTION
Before this change, when a user publish an article, the user identifies was the author/creator of the article not the one who published it, also a new version shoukd be created since publication must be considered as upadte.
 After this commit, the user who published the article is identified in the activity and a newversion is created for publication