### PR TITLE
fix: Fix empty template not displayed in News List portlet - MEED-8582 - Meeds-io/meeds#3097

### DIFF
--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/NewsListView.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/NewsListView.vue
@@ -39,6 +39,7 @@
         v-if="canManageNewsList"
         :saved-header-translations="headerTranslations"
         :language="language"
+        :can-manage-news-list="canManageNewsList"
         :application-id="applicationId" />
       <news-publish-targets-management-drawer v-if="canManageNewsPublishTargets" />
     </v-app>

--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/NewsListView.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/NewsListView.vue
@@ -20,7 +20,7 @@
 -->
 <template>
   <v-hover v-slot="{ hover }">
-    <v-app v-show="!hideEmptyNewsTemplateForNonPublisher" class="news-list-view-app position-relative">
+    <v-app v-show="!hideEmptyNewsTemplate" class="news-list-view-app position-relative">
       <v-card
         :class="newsListViewClass"
         class="application-body application-layout-style overflow-hidden"
@@ -36,7 +36,7 @@
         </v-card-text>
       </v-card>
       <news-settings-drawer
-        v-if="canPublishNews"
+        v-if="canManageNewsList"
         :saved-header-translations="headerTranslations"
         :language="language"
         :application-id="applicationId" />
@@ -116,7 +116,7 @@ export default {
   data: () => ({
     extensionApp: 'NewsList',
     extensionType: 'views',
-    newsList: [null],
+    newsList: [],
     viewExtensions: {},
     loading: false,
     hasMore: false,
@@ -146,7 +146,7 @@ export default {
         const sortedViewExtensions = Object.values(this.viewExtensions).sort();
         return sortedViewExtensions[0];
       }
-      return null;
+      return Object.values(this.viewExtensions).sort()[0];
     },
     selectedViewComponent() {
       return this.selectedViewExtension && {
@@ -189,11 +189,12 @@ export default {
           showArticleReactions: this.showArticleReactions,
           showArticleImage: this.showArticleImage,
           seeAllUrl: this.seeAllUrl,
-        }
+        },
+        canManageNewsList: this.canManageNewsList
       };
     },
-    hideEmptyNewsTemplateForNonPublisher() {
-      return this.selectedViewExtension?.id === 'NewsEmptyTemplate' && !this.canPublishNews;
+    hideEmptyNewsTemplate() {
+      return this.selectedViewExtension?.id === 'NewsEmptyTemplate' && !this.canPublishNews && !this.canManageNewsPublishTargets;
     },
     newsListViewClass() {
       let newsListViewClass = 'list-view-card';
@@ -207,6 +208,9 @@ export default {
       }
       return newsListViewClass;
     },
+    canManageNewsList() {
+      return this.canPublishNews || this.canManageNewsPublishTargets;
+    }
   },
   watch: {
     viewExtensions() {
@@ -230,7 +234,9 @@ export default {
     this.showHeader = this.$root.showHeader;
     this.newsTarget = this.$root.newsTarget;
     this.limit = this.$root.limit;
-    this.retrieveNewsList().finally(() => this.$root.$applicationLoaded());
+    if (this.newsTarget) {
+      this.retrieveNewsList().finally(() => this.$root.$applicationLoaded());
+    }
     document.addEventListener(`component-${this.extensionApp}-${this.extensionType}-updated`, this.refreshViewExtensions);
     this.refreshViewExtensions();
   },

--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/settings/NewsSettingsDrawer.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/settings/NewsSettingsDrawer.vue
@@ -228,6 +228,10 @@ export default {
       type: Object,
       default: null
     },
+    canManageNewsList: {
+      type: Boolean,
+      default: false
+    }
   },
   computed: {
     backgroundColor(){
@@ -306,9 +310,7 @@ export default {
       this.newsTargets.push(newTarget);
       this.newsTarget = newTarget.name;
     });
-    this.$newsServices.canPublishNews().then(canPublishNews => {
-      this.saveSettingsURL = canPublishNews ? this.$root.saveSettingsURL : null;
-    });
+    this.saveSettingsURL = this.canManageNewsList && this.$root.saveSettingsURL || null;
   },
   methods: {
     open() {

--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsEmptyTemplate.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsEmptyTemplate.vue
@@ -21,7 +21,7 @@
 <template>
   <v-hover v-slot="{ hover }">
     <v-app
-      v-show="canPublishNews"
+      v-show="canManageNewsList"
       class="newsEmptyTemplate border-box-sizing"
       flat>
       <v-main>
@@ -60,20 +60,16 @@
 
 <script>
 export default {
-  data () {
-    return {
-      canPublishNews: false,
-    };
+  props: {
+    canManageNewsList: {
+      type: Boolean,
+      default: false
+    }
   },
   computed: {
     isNewsSettingDefined() {
       return this.$root.viewTemplate && this.$root.newsTarget;
     }
-  },
-  created() {
-    this.$newsServices.canPublishNews().then(canPublishNews => {
-      this.canPublishNews = canPublishNews;
-    });
   },
   methods: {
     openDrawer() {


### PR DESCRIPTION
Prior to this change, the News List portlet with an empty template was not displayed when added to a page. This issue was due to a permission check based on the canPublishNews permission, which excluded web contributors after the permission rework. This change introduces a new property, canManageNewsList, which is used to control the visibility of the empty template for users who can manage this portlet