### PR TITLE
fix: Fix empty template not displayed in News List portlet - MEED-8582 - Meeds-io/meeds#3097

### DIFF
--- a/content-service/src/main/java/io/meeds/news/rest/NewsTargetingRest.java
+++ b/content-service/src/main/java/io/meeds/news/rest/NewsTargetingRest.java
@@ -63,6 +63,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 
 @RestController
 @RequestMapping("targeting")
@@ -209,11 +210,11 @@ public class NewsTargetingRest {
       @ApiResponse(responseCode = "403", description = "Forbidden operation"),
       @ApiResponse(responseCode = "409", description = "Conflict operation"),
           @ApiResponse(responseCode = "500", description = "Internal server error")})
-  public Response createNewsTarget(@RequestBody NewsTargetingEntity newsTargetingEntity) {
+  public ResponseEntity<Metadata> createNewsTarget(@RequestBody NewsTargetingEntity newsTargetingEntity) {
     if (newsTargetingEntity.getProperties() == null
             || newsTargetingEntity.getProperties().get(NewsUtils.TARGET_PERMISSIONS) == null
             || newsTargetingEntity.getProperties().get(NewsUtils.TARGET_PERMISSIONS).isEmpty()) {
-      return Response.status(Response.Status.FORBIDDEN).build();
+      throw new ResponseStatusException(HttpStatus.FORBIDDEN);
     }
     org.exoplatform.services.security.Identity currentIdentity = ConversationState.getCurrent().getIdentity();
     try {
@@ -223,20 +224,20 @@ public class NewsTargetingRest {
       targetName.append(System.currentTimeMillis());
       newsTargetingEntity.setName(targetName.toString());
       Metadata addedNewsTarget = newsTargetingService.createNewsTarget(newsTargetingEntity, currentIdentity);
-      return Response.ok(addedNewsTarget).build();
+      return ResponseEntity.ok(addedNewsTarget);
     } catch (IllegalAccessException e) {
       LOG.warn("User '{}' is not authorized to create a news target with name " + newsTargetingEntity.getName(),
                currentIdentity.getUserId(),
                e);
-      return Response.status(Response.Status.UNAUTHORIZED).entity(e.getMessage()).build();
+      throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, e.getMessage());
     } catch (IllegalArgumentException e) {
       LOG.warn("User '{}' can't create a news target with the same name " + newsTargetingEntity.getName(),
                currentIdentity.getUserId(),
                e);
-      return Response.status(Response.Status.CONFLICT).entity(e.getMessage()).build();
+      throw new ResponseStatusException(HttpStatus.CONFLICT, e.getMessage());
     } catch (Exception e) {
       LOG.error("Error when creating a news target with name " + newsTargetingEntity.getName(), e);
-      return Response.serverError().entity(e.getMessage()).build();
+      throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage());
     }
   }
 

--- a/content-service/src/main/java/io/meeds/news/utils/NewsUtils.java
+++ b/content-service/src/main/java/io/meeds/news/utils/NewsUtils.java
@@ -84,11 +84,7 @@ public class NewsUtils {
 
   public static final String ALL_NEWS_AUDIENCE               = "all";
 
-  public static final String PUBLISHER_MEMBERSHIP_NAME       = "publisher";
-
-  public static final String MANAGER_MEMBERSHIP_NAME         = "manager";
-
-  public static final String PLATFORM_WEB_CONTRIBUTORS_GROUP = "/platform/web-contributors";
+  public static final String PLATFORM_ADMINISTRATORS_GROUP = "/platform/administrators";
 
   public static final String ADD_ARTICLE_TRANSLATION         = "content.add.article.translation";
 
@@ -176,7 +172,7 @@ public class NewsUtils {
   }
 
   public static boolean canManageNewsPublishTargets(org.exoplatform.services.security.Identity currentIdentity) {
-    return currentIdentity != null && currentIdentity.isMemberOf(PLATFORM_WEB_CONTRIBUTORS_GROUP, MANAGER_MEMBERSHIP_NAME);
+    return currentIdentity != null && currentIdentity.isMemberOf(PLATFORM_ADMINISTRATORS_GROUP);
   }
 
   public static org.exoplatform.services.security.Identity getUserIdentity(String username) {

--- a/content-service/src/test/java/io/meeds/news/rest/NewsTargetingRestTest.java
+++ b/content-service/src/test/java/io/meeds/news/rest/NewsTargetingRestTest.java
@@ -20,6 +20,7 @@
 package io.meeds.news.rest;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.lenient;
 
 import static org.mockito.Mockito.when;
@@ -51,6 +52,7 @@ import io.meeds.news.service.NewsTargetingService;
 import io.meeds.news.utils.NewsUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.server.ResponseStatusException;
 
 @RunWith(MockitoJUnitRunner.class)
 public class NewsTargetingRestTest {
@@ -154,18 +156,16 @@ public class NewsTargetingRestTest {
     lenient().when(newsTargetingService.createNewsTarget(newsTargetingEntity, currentIdentity)).thenReturn(sliderNews);
 
     // When
-    Response response = newsTargetingRestController.createNewsTarget(newsTargetingEntity);
+    ResponseEntity response = newsTargetingRestController.createNewsTarget(newsTargetingEntity);
 
     // Then
-    assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+    assertEquals(HttpStatus.OK, response.getStatusCode());
 
     when(newsTargetingRestController.createNewsTarget(newsTargetingEntity)).thenThrow(RuntimeException.class);
 
     // When
-    response = newsTargetingRestController.createNewsTarget(newsTargetingEntity);
+    assertThrows(ResponseStatusException.class, () -> newsTargetingRestController.createNewsTarget(newsTargetingEntity));
 
-    // Then
-    assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
 
   }
 

--- a/content-service/src/test/java/io/meeds/news/service/impl/NewsTargetingImplTest.java
+++ b/content-service/src/test/java/io/meeds/news/service/impl/NewsTargetingImplTest.java
@@ -98,9 +98,6 @@ public class NewsTargetingImplTest {
   SpaceService                                           spaceService;
 
   @Mock
-  Space                                                  space;
-
-  @Mock
   ExoContainer                                           container;
 
   @Mock
@@ -126,7 +123,7 @@ public class NewsTargetingImplTest {
   }
 
   @Test
-  public void testGetAllTargets() throws Exception {
+  public void testGetAllTargets() {
     // Given
     EXO_CONTAINER_CONTEXT.when(() -> ExoContainerContext.getService(IdentityRegistry.class)).thenReturn(identityRegistry);
     REST_UTILS.when(() -> RestUtils.getCurrentUser()).thenReturn("root");
@@ -437,7 +434,7 @@ public class NewsTargetingImplTest {
   public void testCreateTarget() throws IllegalAccessException {
     // Given
     org.exoplatform.services.security.Identity currentIdentity = new org.exoplatform.services.security.Identity("root");
-    MembershipEntry membershipentry = new MembershipEntry("/platform/web-contributors", "manager");
+    MembershipEntry membershipentry = new MembershipEntry("/platform/administrators", "manager");
     List<MembershipEntry> memberships = new ArrayList<MembershipEntry>();
     memberships.add(membershipentry);
     currentIdentity.setMemberships(memberships);
@@ -499,7 +496,7 @@ public class NewsTargetingImplTest {
   public void testUpdateTarget() throws IllegalAccessException {
     // Given
     org.exoplatform.services.security.Identity currentIdentity = new org.exoplatform.services.security.Identity("root");
-    MembershipEntry membershipentry = new MembershipEntry("/platform/web-contributors", "manager");
+    MembershipEntry membershipentry = new MembershipEntry("/platform/administrators", "manager");
     List<MembershipEntry> memberships = new ArrayList<MembershipEntry>();
     memberships.add(membershipentry);
     currentIdentity.setMemberships(memberships);

--- a/content-webapp/src/main/webapp/WEB-INF/jsp/newsListView.jsp
+++ b/content-webapp/src/main/webapp/WEB-INF/jsp/newsListView.jsp
@@ -3,8 +3,9 @@
 <%@ page import="io.meeds.news.utils.NewsUtils" %>
 <%@ page import="org.exoplatform.web.PortalHttpServletResponseWrapper" %>
 <%@ page import="org.exoplatform.portal.application.PortalRequestContext" %>
-<%@ page import="org.exoplatform.commons.api.settings.ExoFeatureService" %>
 <%@ page import="org.exoplatform.commons.utils.CommonsUtils" %>
+<%@ page import="org.exoplatform.portal.config.UserACL" %>
+<%@ page import="org.exoplatform.portal.config.model.Page" %>
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
 <portlet:defineObjects />
@@ -61,10 +62,12 @@
     String newsListUrl = "/content/rest/contents/byTarget/" + newsTarget + "?offset=0&limit=" + limit + "&returnSize=true";
     responseWrapper.addHeader("Link", "<" + newsListUrl + ">; rel=prefetch; as=fetch; crossorigin=use-credentials", false);
     boolean canManageNewsPublishTargets = NewsUtils.canManageNewsPublishTargets(currentIdentity);
+    UserACL userACL = CommonsUtils.getService(UserACL.class);
+    Page currentPage = rcontext.getPage();
+    boolean hasEditPermission = currentIdentity != null && userACL.hasEditPermission(currentPage, currentIdentity);
   %>
   <div class="news-list-view-app" id="<%= appId %>">
     <script type="text/javascript">
-      eXo.env.portal.canManageNewsPublishTargets = <%=canManageNewsPublishTargets%>;
       require(['PORTLET/content/NewsListView'], app => app.init({
         applicationId: '<%=applicationId%>',
         appId: '<%=appId%>',
@@ -82,7 +85,9 @@
         showArticleSpace: <%= showArticleSpace == null ? null : "'" + showArticleSpace + "'" %>,
         showArticleReactions: <%= showArticleReactions == null ? null : "'" + showArticleReactions + "'" %>,
         showArticleDate: <%= showArticleDate == null ? null : "'" + showArticleDate + "'" %>,
-        seeAllUrl: <%= seeAllUrl == null ? null : "'" + seeAllUrl + "'" %>
+        seeAllUrl: <%= seeAllUrl == null ? null : "'" + seeAllUrl + "'" %>,
+        canManageNewsList: <%= hasEditPermission %>,
+        canManageNewsPublishTargets: <%=canManageNewsPublishTargets%>,
       }));
     </script>
   </div>

--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/NewsListView.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/NewsListView.vue
@@ -39,9 +39,8 @@
         v-if="canManageNewsList"
         :saved-header-translations="headerTranslations"
         :language="language"
-        :can-manage-news-list="canManageNewsList"
         :application-id="applicationId" />
-      <news-publish-targets-management-drawer v-if="canManageNewsPublishTargets" />
+      <news-publish-targets-management-drawer v-if="canManageNewsTarget" />
     </v-app>
   </v-hover>
 </template>
@@ -122,8 +121,6 @@ export default {
     loading: false,
     hasMore: false,
     offset: 0,
-    canPublishNews: false,
-    canManageNewsPublishTargets: eXo.env.portal.canManageNewsPublishTargets,
     language: eXo?.env?.portal?.language,
   }),
   computed: {
@@ -191,11 +188,10 @@ export default {
           showArticleImage: this.showArticleImage,
           seeAllUrl: this.seeAllUrl,
         },
-        canManageNewsList: this.canManageNewsList
       };
     },
     hideEmptyNewsTemplate() {
-      return this.selectedViewExtension?.id === 'NewsEmptyTemplate' && !this.canPublishNews && !this.canManageNewsPublishTargets;
+      return this.selectedViewExtension?.id === 'NewsEmptyTemplate' && !this.canManageNewsList;
     },
     newsListViewClass() {
       let newsListViewClass = 'list-view-card';
@@ -210,7 +206,10 @@ export default {
       return newsListViewClass;
     },
     canManageNewsList() {
-      return this.canPublishNews || this.canManageNewsPublishTargets;
+      return this.$root.canManageNewsList || this.$root.canPublishNews;
+    },
+    canManageNewsTarget() {
+      return this.$root.canManageNewsTarget || false;
     }
   },
   watch: {
@@ -219,9 +218,6 @@ export default {
     },
   },
   created() {
-    this.$newsServices.canPublishNews().then(canPublishNews => {
-      this.canPublishNews = canPublishNews;
-    });
     this.$root.$on('saved-news-settings', (newsTarget, selectedOptions) => {
       this.seeAllUrl = selectedOptions.seeAllUrl;
       this.showSeeAll = selectedOptions.showSeeAll;

--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/settings/NewsSettingsDrawer.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/settings/NewsSettingsDrawer.vue
@@ -109,7 +109,7 @@
               </template>
             </v-select>
           </div>
-          <div v-if="canManageNewsPublishTargets" class="d-flex flex-row clickable text-decoration-underline">
+          <div v-if="$root.canManageNewsTarget" class="d-flex flex-row clickable text-decoration-underline">
             <a @click="createNewTarget"> {{ $t('news.list.settings.drawer.createNewTarget') }} </a>
           </div>
           <div v-if="newsTargets.length === 0" class="d-flex flex-row grey--text">
@@ -211,7 +211,6 @@ export default {
     seeAllUrl: '',
     isValidSeeAllUrl: false,
     saveSettingsURL: '',
-    canManageNewsPublishTargets: eXo.env.portal.canManageNewsPublishTargets,
     translationObjectType: 'newsListView',
     headerTitleFieldName: 'headerNameInput',
   }),
@@ -228,10 +227,6 @@ export default {
       type: Object,
       default: null
     },
-    canManageNewsList: {
-      type: Boolean,
-      default: false
-    }
   },
   computed: {
     backgroundColor(){
@@ -310,7 +305,7 @@ export default {
       this.newsTargets.push(newTarget);
       this.newsTarget = newTarget.name;
     });
-    this.saveSettingsURL = this.canManageNewsList && this.$root.saveSettingsURL || null;
+    this.saveSettingsURL = (this.$root.canManageNewsList || this.$root.canPublishNews) && this.$root.saveSettingsURL || null;
   },
   methods: {
     open() {

--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsEmptyTemplate.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsEmptyTemplate.vue
@@ -21,7 +21,7 @@
 <template>
   <v-hover v-slot="{ hover }">
     <v-app
-      v-show="canManageNewsList"
+      v-show="$root.canManageNewsList || $root.canPublishNews"
       class="newsEmptyTemplate border-box-sizing"
       flat>
       <v-main>

--- a/content-webapp/src/main/webapp/vue-app/news-list-view/main.js
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/main.js
@@ -76,6 +76,8 @@ export function init(params) {
   const showArticleReactions = params.showArticleReactions === '' ? true : params.showArticleReactions === 'true';
   const showArticleDate  = params.showArticleDate === '' ? true : params.showArticleDate === 'true';
   const seeAllUrl = params.seeAllUrl;
+  const canManageNewsList = params.canManageNewsList;
+  const canManageNewsTarget = params.canManageNewsPublishTargets;
 
   exoi18n.loadLanguageAsync(lang, url).then(i18n => {
     // init Vue app when locale resources are ready
@@ -98,13 +100,19 @@ export function init(params) {
         showArticleReactions,
         showArticleDate,
         seeAllUrl,
-        defaultLanguage: eXo?.env?.portal?.defaultLanguage
+        defaultLanguage: eXo?.env?.portal?.defaultLanguage,
+        canManageNewsList,
+        canManageNewsTarget,
+        canPublishNews: false
       },
       created() {
         Vue.prototype.$translationService.getTranslations('newsListView', applicationId, 'headerNameInput').then(translations => {
           this.headerTranslations = translations;
           this.headerTitle = translations?.[lang] || translations?.[this.defaultLanguage]
                                                   || params.headerTitle;
+        });
+        this.$newsServices.canPublishNews().then(canPublishNews => {
+          this.canPublishNews = canPublishNews;
         });
       },
       template: `<news-list-view

--- a/content-webapp/src/main/webapp/vue-app/news-publish-targets-management/components/NewsPublishTargetsManagementDrawer.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-publish-targets-management/components/NewsPublishTargetsManagementDrawer.vue
@@ -221,7 +221,6 @@ export default {
   created() {
     this.$root.$on('selected-target', (selectedTarget) => {
       this.selectedTarget = selectedTarget;
-      console.log(this.selectedTarget);
       this.originalTargetName = selectedTarget.targetName;
       this.targetLabel = selectedTarget.targetLabel;
       this.targetDescription = selectedTarget.targetDescription;


### PR DESCRIPTION
Prior to this change, the News List portlet with an empty template was not displayed when added to a page. This issue was due to a permission check based on the canPublishNews permission, which excluded web contributors after the permission rework. This change introduces a new property, canManageNewsList, which is used to control the visibility of the empty template for users who can manage this portlet