### PR TITLE
fix: Fix translation menu item color - MEED-8605 - Meeds-io/meeds#3127

### DIFF
--- a/content-webapp/src/main/webapp/skin/less/newsDetails.less
+++ b/content-webapp/src/main/webapp/skin/less/newsDetails.less
@@ -256,6 +256,10 @@
 
 }
 
+.translation-chips .v-chip.v-chip--outlined.v-chip.v-chip {
+  color: @primaryColor !important;
+}
+
 /*====================== Responsive ==========================*/
 
 @media screen and (max-width: 480px) {


### PR DESCRIPTION
Prior to this change, the outlined class applied to the V-Ship translation menu item was ignoring the primary background color, and the white text color prevented the primary text label from being displayed properly. This change applies the primary color to the V-Ship, resolving the issue.