### PR TITLE
fix: Space admin cannot configure the news list in space - MEED-8661 - Meeds-io/meeds#3158

### DIFF
--- a/content-webapp/src/main/webapp/vue-app/news-list-view/main.js
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/main.js
@@ -114,8 +114,8 @@ export function init(params) {
         });
         this.$newsServices.canPublishNews().then(canPublishNews => {
           this.canPublishNews = canPublishNews;
+          this.canManageNewsList = this.canEditNewsList || this.canPublishNews;
         });
-        this.canManageNewsList = this.canEditNewsList || this.canPublishNews;
       },
       template: `<news-list-view
                   id="${appId}"


### PR DESCRIPTION
Prior to this change, the space admin could not configure the news list in a space. This issue was due to the wrong initialization of the canManageNewsList variable. This change is going to correctly initialize the canManageNewsList variable, resolving this issue.