### PR TITLE
ix: No date displayed when enabling the display date in the news list portlet - MEED-8599 - Meeds-io/meeds#3095

### DIFF
--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsCardsViewItem.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsCardsViewItem.vue
@@ -127,7 +127,7 @@ export default {
   }),
   computed: {
     displayDate() {
-      return this.item.publishDate && this.item.publishDate.time && new Date(this.item.publishDate.time);
+      return this.item.publishDate && new Date(this.item.publishDate);
     },
     showArticleAuthor() {
       return this.selectedOption && this.selectedOption.showArticleAuthor && this.item && !this.item.properties.hideAuthor;

--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsLatestViewItem.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsLatestViewItem.vue
@@ -121,7 +121,7 @@ export default {
       return this.illustrationURL() || '/content/images/news.png';
     },
     displayDate() {
-      return this.item.publishDate && this.item.publishDate.time && new Date(this.item.publishDate.time);
+      return this.item.publishDate && new Date(this.item.publishDate);
     },
     isHiddenSpace() {
       return this.item && !this.item.spaceMember && this.item.hiddenSpace;

--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsListTemplateViewItem.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsListTemplateViewItem.vue
@@ -97,7 +97,7 @@ export default {
   }),
   computed: {
     displayDate() {
-      return this.item?.publishDate?.time && new Date(this.item.publishDate.time);
+      return this.item?.publishDate && new Date(this.item.publishDate);
     },
     showArticleImage() {
       return this.selectedOption?.showArticleImage;

--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsSliderViewItem.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsSliderViewItem.vue
@@ -152,7 +152,7 @@ export default {
   }),
   computed: {
     displayDate() {
-      return this.publishDate && this.publishDate.time && new Date(this.publishDate.time);
+      return this.publishDate && new Date(this.publishDate);
     },
     isHiddenSpace() {
       return !this.spaceMember && this.hiddenSpace;

--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsStoriesViewItem.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsStoriesViewItem.vue
@@ -104,7 +104,7 @@ export default {
   }),
   computed: {
     displayDate() {
-      return this.item.publishDate && this.item.publishDate.time && new Date(this.item.publishDate.time);
+      return this.item.publishDate && new Date(this.item.publishDate);
     },
     showArticleAuthor() {
       return this.selectedOption && this.selectedOption.showArticleAuthor && this.item  && !this.item.properties.hideAuthor;


### PR DESCRIPTION
Prior to this change, no date was displayed when enabling the display date in the news list portlet, this issue due to an incorrect compute of the display date , this change is going to compute correctly the display date 