### PR TITLE
fix: Display the article summary as sanitized HTML - MEED-8600 - Meeds-io/meeds#3121

### DIFF
--- a/content-webapp/src/main/webapp/vue-app/news-details/components/ExoNewsDetailsBody.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-details/components/ExoNewsDetailsBody.vue
@@ -78,8 +78,8 @@
         </div>
         <p
           v-if="newsSummary"
+          v-sanitized-html="newsSummary"
           class="article-summary text-break text-sub-title mt-4 mb-0">
-          {{ newsSummary }}
         </p>
         <div class="mt-4">
           <div


### PR DESCRIPTION
Prior to this change the content article summary was displayed as text , this change is going to display the article summary as sanitized HTML.