### PR TITLE
fix: Prevent space members from referring articles they do not own - MEED-8662 - Meeds-io/meeds#3146

### DIFF
--- a/content-service/src/main/java/io/meeds/news/service/impl/NewsServiceImpl.java
+++ b/content-service/src/main/java/io/meeds/news/service/impl/NewsServiceImpl.java
@@ -287,7 +287,7 @@ public class NewsServiceImpl implements NewsService {
     if (POSTING_AND_PUBLISHING.name().equalsIgnoreCase(newsUpdateType) && (!canEditNews(news, updater) && !NewsUtils.canPublishNews(news.getSpaceId(), updaterIdentity))) {
       throw new IllegalAccessException("User " + updater + " is not authorized to update news");
     }
-    if (PAGE_REFERENCE.name().equalsIgnoreCase(newsUpdateType) && !NewsUtils.canReferToNote(news, updaterIdentity)) {
+    if (PAGE_REFERENCE.name().equalsIgnoreCase(newsUpdateType) && !canReferToNote(news, updaterIdentity)) {
       throw new IllegalAccessException("User " + updater + " is not authorized to refer or derefer news");
     }
     
@@ -529,7 +529,7 @@ public class NewsServiceImpl implements NewsService {
       news.setCanEdit(canEditNews(news, currentIdentity.getUserId()));
       news.setCanDelete(canEditNews(news, currentIdentity.getUserId()));
       news.setCanPublish(NewsUtils.canPublishNews(news.getSpaceId(), currentIdentity));
-      news.setCanRefer(NewsUtils.canReferToNote(news, currentIdentity));
+      news.setCanRefer(canReferToNote(news, currentIdentity));
       news.setCanSchedule(canScheduleNews(news.getSpaceId(), currentIdentity, news));
       news.setTargets(newsTargetingService.getTargetsByNews(news));
       ExoSocialActivity activity = null;
@@ -595,7 +595,7 @@ public class NewsServiceImpl implements NewsService {
       news.setCanEdit(canEditNews(news, currentIdentity.getUserId()));
       news.setCanDelete(canEditNews(news, currentIdentity.getUserId()));
       news.setCanPublish(NewsUtils.canPublishNews(news.getSpaceId(), currentIdentity));
-      news.setCanRefer(NewsUtils.canReferToNote(news, currentIdentity));
+      news.setCanRefer(canReferToNote(news, currentIdentity));
       news.setCanSchedule(canScheduleNews(news.getSpaceId(), currentIdentity, news));
     });
     return newsList;
@@ -1215,6 +1215,18 @@ public class NewsServiceImpl implements NewsService {
         && (news.isReferred() || news.isFromExternalPage() || isArticleOwner(news, authenticatedUser)))
         || spaceService.isManager(space, authenticatedUser) || spaceService.isSuperManager(space, authenticatedUser)
         || spaceService.isRedactor(space, authenticatedUser);
+  }
+
+  private boolean canReferToNote(News article, org.exoplatform.services.security.Identity currentIdentity) {
+    Space space = spaceService.getSpaceById(article.getSpaceId());
+    if (space == null || currentIdentity == null) {
+      return false;
+    }
+    if (article.isFromExternalPage()) {
+      return false;
+    }
+    return canEditNews(article, currentIdentity.getUserId())
+            || spaceService.canPublishOnSpace(space, currentIdentity.getUserId());
   }
 
   private void deleteAllDrafts(Page articlePage, String articleCreator) {

--- a/content-service/src/main/java/io/meeds/news/utils/NewsUtils.java
+++ b/content-service/src/main/java/io/meeds/news/utils/NewsUtils.java
@@ -256,18 +256,6 @@ public class NewsUtils {
     return illustrationUrl.toString();
   }
 
-  public static boolean canReferToNote(News article, org.exoplatform.services.security.Identity currentIdentity) {
-    Space space = getSpaceService().getSpaceById(article.getSpaceId());
-    if (space == null || currentIdentity == null) {
-      return false;
-    }
-    if (article.isFromExternalPage()) {
-      return false;
-    }
-    return getSpaceService().canRedactOnSpace(space, currentIdentity)
-        || getSpaceService().canPublishOnSpace(space, currentIdentity.getUserId());
-  }
-
   public static List<String> toTargetNames(List<ArticleTarget> articleTargets) {
     if (articleTargets == null || articleTargets.isEmpty()) {
       return new ArrayList<>();

--- a/content-service/src/test/java/io/meeds/news/utils/NewsUtilsTest.java
+++ b/content-service/src/test/java/io/meeds/news/utils/NewsUtilsTest.java
@@ -87,25 +87,4 @@ public class NewsUtilsTest {
     when(spaceService.canPublishOnSpace(space, userAclIdentity.getUserId())).thenReturn(true);
     assertTrue(NewsUtils.canPublishNews(space.getId(), userAclIdentity));
   }
-
-  @Test
-  public void testCanReferArticleToNote() {
-    News article = new News();
-    article.setSpaceId("2");
-    when(userAclIdentity.getUserId()).thenReturn("user");
-    when(spaceService.getSpaceById("2")).thenReturn(null, space);
-    assertFalse(NewsUtils.canReferToNote(article, null));
-    assertFalse(NewsUtils.canReferToNote(article, null));
-
-    article.setFromExternalPage(true);
-    assertFalse(NewsUtils.canReferToNote(article, userAclIdentity));
-    article.setFromExternalPage(false);
-    when(spaceService.canRedactOnSpace(space, userAclIdentity)).thenReturn(false, true, false, true);
-    when(spaceService.canPublishOnSpace(space, "user")).thenReturn(false, true, true, false);
-    assertFalse(NewsUtils.canReferToNote(article, userAclIdentity));
-
-    assertTrue(NewsUtils.canReferToNote(article, userAclIdentity));
-    assertTrue(NewsUtils.canReferToNote(article, userAclIdentity));
-    assertTrue(NewsUtils.canReferToNote(article, userAclIdentity));
-  }
 }


### PR DESCRIPTION
Prior to this change, space members were able to refer and edit a referred article that they did not own. This change prevents space members from referring to articles they do not own.
Resolves https://github.com/Meeds-io/meeds/issues/3146