### PR TITLE
fix: Prevent articles with canceled scheduling from being posted - MEED-8593 - Meeds-io/meeds#3092

### DIFF
--- a/content-service/src/main/java/io/meeds/news/job/PostScheduledNewsArticleJob.java
+++ b/content-service/src/main/java/io/meeds/news/job/PostScheduledNewsArticleJob.java
@@ -71,7 +71,8 @@ public class PostScheduledNewsArticleJob {
                      try {
                        if (scheduledArticleMetadataItem.getProperties() != null && !scheduledArticleMetadataItem.getProperties().isEmpty()) {
                          String articleScheduleDate = scheduledArticleMetadataItem.getProperties().getOrDefault(SCHEDULE_POST_DATE, null);
-                         if (articleScheduleDate != null) {
+                         boolean articleDeleted = Boolean.parseBoolean(scheduledArticleMetadataItem.getProperties().getOrDefault(NEWS_DELETED, null));
+                         if (articleScheduleDate != null && !articleDeleted) {
 
                            if (isScheduleDatePassed(articleScheduleDate)) {
                              // return only the metadata items with a schedule date property equals or prior to


### PR DESCRIPTION
Prior to this change, articles with canceled scheduling were posted on their previously scheduled date. This was because canceling the scheduling of an article and converting it to a draft removed the article and created a new draft. Additionally, there was no check for deleted articles in the scheduling job's behavior. This change will prevent deleted articles from being posted

(cherry picked from commit f239563d197e0e437f4909c58ad76d5e8e0f145c)