### PR TITLE
fix: No vertical scroll provided for list template - MEED-8702 - Meeds-io/meeds#3187.

### DIFF
--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/NewsListView.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/NewsListView.vue
@@ -205,6 +205,8 @@ export default {
       }
       if (this.viewTemplate !== 'NewsList') {
         newsListViewClass = `${newsListViewClass} overflow-hidden`;
+      } else {
+        newsListViewClass = `${newsListViewClass} specific-scrollbar`;
       }
       return newsListViewClass;
     },


### PR DESCRIPTION
Before this change, when Add a newsList to the page using layout editor and choose to list more than 4 articles then fix the height to 400px, no scroll provided like it is for other portlet when fixing the height and while there is more items to list than the height can display. To fix this problem, remove the overflow-hidden class from the card. After this change, a vertical scroll is provided when there are more items to list in the newslist portlet than the fixed height can display.