### PR TITLE
fix: No vertical scroll provided for list template - MEED-8702 - Meeds-io/meeds#3187

### DIFF
--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/NewsListView.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/NewsListView.vue
@@ -23,7 +23,7 @@
     <v-app v-show="!hideEmptyNewsTemplate" class="news-list-view-app position-relative">
       <v-card
         :class="newsListViewClass"
-        class="application-body application-layout-style overflow-hidden"
+        class="application-body application-layout-style"
         height="100%"
         flat>
         <v-card-text class="pa-0">
@@ -202,6 +202,9 @@ export default {
       }
       if (backgroundTransparent) {
         newsListViewClass = `${newsListViewClass} background-transparent`;
+      }
+      if (this.viewTemplate !== 'NewsList') {
+        newsListViewClass = `${newsListViewClass} overflow-hidden`;
       }
       return newsListViewClass;
     },

--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/NewsListView.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/NewsListView.vue
@@ -205,6 +205,8 @@ export default {
       }
       if (this.viewTemplate !== 'NewsList') {
         newsListViewClass = `${newsListViewClass} overflow-hidden`;
+      } else {
+        newsListViewClass = `${newsListViewClass} specific-scrollbar`;
       }
       return newsListViewClass;
     },


### PR DESCRIPTION
Before this change, when Add a newsList to the page using layout editor and choose to list more than 4 articles then fix the height to 400px, no scroll provided like it is for other portlet when fixing the height and while there is more items to list than the height can display. To fix this problem, remove the overflow-hidden class from the card. After this change, a vertical scroll is provided when there are more items to list in the newslist portlet than the fixed height can display.

(cherry-picked from https://github.com/Meeds-io/content/commit/8dbf0181d101ab821ecba3ffe5aa97bde51c25ca & https://github.com/Meeds-io/content/commit/5a7fb96d74b505c3df4a3b1db9f3e5009abeb921)