### PR TITLE
fix: Newslists templates do not get text styling from layout options - MEED-8704 - Meeds-io/meeds#3116

### DIFF
--- a/content-webapp/src/main/webapp/skin/less/newsListView.less
+++ b/content-webapp/src/main/webapp/skin/less/newsListView.less
@@ -47,12 +47,6 @@
       }
       .latestNewsTitleContainer {
         position: relative;
-
-        .news-text-header {
-          font-size: 18px!important;
-          color: var(--allPagesGreyColorLighten1,#707070)!important;
-          font-weight: normal!important
-        }
       }
     }
 
@@ -127,7 +121,6 @@
                 -webkit-line-clamp: 1;
                 -webkit-box-orient: vertical;
                 overflow: hidden;
-                font-size: 1.7rem !important;
                 line-height: 3rem;
                 padding-bottom: 0px;
                 margin: 0px 30px;
@@ -1105,27 +1098,7 @@ p.caption-title:after {
   background-color: @primaryColorDefault;
 
   .alerts-header {
-    display: -webkit-box;
-    display: -ms-flexbox;
-    display: flex;
-    -webkit-box-align: center;
-    -ms-flex-align: center;
-    align-items: center;
-    height: 100%;
     background-color: @alertHeadingColor;
-    z-index: 1;
-    span {
-      margin-left: -4px;
-      padding-right: 15px;
-      font-weight: bold;
-      text-transform: uppercase;
-    }
-    .alerts-icon {
-      padding: 0 12px 0 13px;
-      i {
-        color: white;
-      }
-    }
   }
 
   .alerts-viewer {
@@ -1138,26 +1111,6 @@ p.caption-title:after {
       color: white;
       text-decoration: none;
       padding-right: 90px;
-      .alerts-article {
-        display: -webkit-box;
-        display: -ms-flexbox;
-        display: flex;
-        .alerts-article-date {
-          white-space: nowrap;
-          color: white;
-          letter-spacing: 0;
-          text-transform: capitalize;
-        }
-        .alerts-article-seperator {
-          margin: 0 6px 0 7px;
-        }
-        .alerts-article-title {
-          letter-spacing: 0.1px;
-          overflow: hidden;
-          white-space: nowrap;
-          text-overflow: ellipsis;
-        }
-      }
     }
   }
 
@@ -1203,10 +1156,6 @@ p.caption-title:after {
         -webkit-transform: translateY(0);
         -ms-transform: translateY(0);
         transform: translateY(0);
-      }
-      .article-summary {
-        color: @textColor;
-        margin-top: 8px;
       }
     }
   }
@@ -1309,17 +1258,6 @@ p.caption-title:after {
       color: @primaryColor;
     }
   }
-  .article-author-date {
-    font-size: 12px;
-    color: @greyColorLighten1;
-    display: -webkit-box;
-    display: -ms-flexbox;
-    display: flex;
-    overflow: hidden;
-    -o-text-overflow: ellipsis;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
   .author-name {
     overflow: hidden;
     -o-text-overflow: ellipsis;
@@ -1329,39 +1267,8 @@ p.caption-title:after {
   .date {
     color: @greyColorLighten1;
   }
-  .article-summary {
-    font-size: 13px;
-    line-height: 17px;
-    display: -webkit-box;
-    -webkit-box-orient: vertical;
-    -webkit-line-clamp: 6;
-    overflow: hidden;
-    margin-top: 20px;
-  }
-  .read-more {
-    font-size: 12px;
-    color: @primaryColor;
-    font-weight: bold;
-    -ms-flex-item-align: center;
-    -ms-grid-row-align: center;
-    align-self: center;
-    margin-top: 8px;
-    z-index: 2;
-    &::after {
-      content: " →";
-      font-size: 11px;
-    }
-    &:hover {
-      color: @greyColorLighten1;
-    }
-  }
   .bottom-row {
     background: white;
-    position: absolute;
-    bottom: 0;
-    width: 100%;
-    border-top: 1px solid @tableBackgroundAccent;
-    padding: 10px 12px 8px 12px;
   }
   .article-counters {
     font-size: 12px;
@@ -1376,18 +1283,6 @@ p.caption-title:after {
     display: flex;
     float: left;
     color: @greyColorLighten1;
-  }
-  .reactionsLink {
-    position: absolute;
-    display: block;
-    padding: 6px 10px 3px 9px;
-    left: 1px;
-    top: 5px;
-    border-radius: 25px;
-    z-index: 2;
-    &:hover {
-      background-color: rgba(87, 141, 201, 0.09);
-    }
   }
   .likes-count {
     float: right;
@@ -1482,8 +1377,6 @@ p.caption-title:after {
   }
   .article-preTitle {
     display: block;
-    font-size: 12px;
-    line-height: 12px;
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
@@ -1491,7 +1384,6 @@ p.caption-title:after {
   }
   .article-title {
     width: 100%;
-    font-size: @textFontSize;
     color:  @textColor;
     transition: 0.3s;
     line-height: 20px;
@@ -1499,12 +1391,6 @@ p.caption-title:after {
     display: -webkit-box;
     -webkit-box-orient: vertical;
     -webkit-line-clamp: 1;
-  }
-  .article-postTitle {
-    display: flex;
-    overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
   }
   .reactions {
     display: flex;

--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/settings/NewsSettings.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/settings/NewsSettings.vue
@@ -23,7 +23,7 @@
     <div class="d-flex latestNewsTitleContainer flex-column flex-grow-1 my-1 text-truncate">
       <span
         v-if="showHeader"
-        class="news-text-header text-truncate"
+        class="widget-text-header text-truncate"
         :title="headerTitle">{{ headerTitle }}</span>
     </div>
     <div :class="[showHeader && headerTitle ? 'd-flex flex-column me-2 mt-1' : 'd-flex flex-column me-2']">

--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsAlertView.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsAlertView.vue
@@ -24,11 +24,11 @@
       class="card-border-radius"
       id="critical-alerts-slider"
       v-show="!emptyTemplate">
-      <div class="alerts-header">
-        <div class="alerts-icon">
-          <v-icon>warning</v-icon>
+      <div class="alerts-header white--text z-index-one fill-height align-center d-flex text-header">
+        <div class="px-3">
+          <v-icon color="white">warning</v-icon>
         </div>
-        <span class="d-none d-md-block" v-if="showHeader">{{ headerTitle }}</span>
+        <span class="d-none d-md-block ms-n1 pe-4 font-weight-bold text-uppercase" v-if="showHeader">{{ headerTitle }}</span>
       </div>
 
       <div class="alerts-viewer ps-5 flex-grow-1">
@@ -43,14 +43,14 @@
             v-for="(item,i) in news"
             :key="i">
             <a :href="articleUrl(item)" class="article-link flex-grow-1">
-              <div class="alerts-article">
-                <span v-if="showArticleDate" class="alerts-article-date">
+              <div class="alerts-article d-flex text-body white--text">
+                <span v-if="showArticleDate" class="text-no-wrap text-capitalize">
                   <date-format
                     :value="new Date(item?.publishDate)"
                     :format="dateFormat" />
                 </span>
-                <span v-if="showArticleDate && showArticleTitle" class="alerts-article-seperator">|</span>
-                <span v-if="showArticleTitle" class="alerts-article-title">{{ item.title }}</span>
+                <span v-if="showArticleDate && showArticleTitle" class="mx-2">|</span>
+                <span v-if="showArticleTitle" class="text-truncate text-no-wrap overflow-hidden">{{ item.title }}</span>
               </div>
             </a>
           </v-carousel-item>

--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsCardsViewItem.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsCardsViewItem.vue
@@ -45,46 +45,45 @@
               class="space-icon"
               :src="item.spaceAvatarUrl"
               :alt="$t('news.space.icon.alt',{ 0:item.spaceDisplayName })">
-            <div class="space-name">{{ item.spaceDisplayName }}</div>
+            <div class="space-name text-subtitle">{{ item.spaceDisplayName }}</div>
           </div>
         </a>
         <a
           class="articleLink"
           target="_self"
           :href="articleUrl">
-          <div v-if="showArticleTitle" class="article-title">{{ item.title }}</div>
-          <div class="article-author-date">
+          <div v-if="showArticleTitle" class="article-title text-body">{{ item.title }}</div>
+          <div class="d-flex text-no-wrap text-truncate text-subtitle">
             <div v-if="showArticleAuthor" class="author-name">{{ item.authorDisplayName }}</div>
                 
             <span v-if="showArticleAuthor && showArticleDate">,&nbsp;</span>
-            <div v-if="showArticleDate" class="date">
+            <div v-if="showArticleDate">
               <date-format
                 :value="displayDate"
                 :format="dateFormat" />
             </div>
                 
           </div>
-          <div v-if="showArticleSummary" class="article-summary"> {{ item?.properties?.summary }} </div>
-          <div class="read-more">{{ $t('news.cards.readMore') }}</div>
+          <div v-if="showArticleSummary" class="d-flex text-color mt-4 text-subtitle"> {{ item?.properties?.summary }} </div>
+          <div class="mt-2 align-self-center text-subtitle font-weight-bold primary--text">{{ $t('news.cards.readMore') }}</div>
         </a>
       </div>
-      <div v-if="showArticleReactions" class="bottom-row">
-        <div class="article-counters">
+      <div v-if="showArticleReactions" class="bottom-row border-top-color pa-2 width-full b-0 position-absolute white-background text-subtitle">
+        <div class="d-flex text-truncate text-no-wrap">
           <a
-            class="reactionsLink"
+            class="width-fit-content"
             target="_self"
             :href="activityReactionsLink">
-            <div class="reactions">
+            <div class="d-flex text-truncate text-subtitle">
               <v-icon
-                class="counters-icons"
                 size="14">mdi-thumb-up</v-icon>
-              <div class="likes-count">{{ item.likesCount }}</div>
+              <div class="likes-count ms-1">{{ item.likesCount }}</div>
               <v-icon
                 class="counters-icons mt-1 ml-2"
                 size="14">
                 mdi-comment
               </v-icon>
-              <div class="comments-count">{{ item.commentsCount }}</div>
+              <div class="comments-count ms-1">{{ item.commentsCount }}</div>
             </div>
           </a>
           <a
@@ -95,7 +94,7 @@
               <v-icon
                 class="counters-icons"
                 size="16">mdi-eye</v-icon>
-              <div class="views-count">{{ item.viewsCount }}</div>
+              <div class="views-count ms-1">{{ item.viewsCount }}</div>
             </div>
           </a>
         </div>

--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsLatestViewItem.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsLatestViewItem.vue
@@ -31,16 +31,16 @@
         class="card-border-radius">
     </div>
     <div class="articleInfos">
-      <div class="articleSpace" v-if="!isHiddenSpace && showArticleSpace">
+      <div class="articleSpace text-subtitle" v-if="!isHiddenSpace && showArticleSpace">
         <img
           class="spaceImage"
           :src="item.spaceAvatarUrl"
           :alt="$t('news.space.icon.alt',{ 0:item.spaceDisplayName })">
         <span class="spaceName">{{ item.spaceDisplayName }}</span>
       </div>
-      <span v-if="showArticleTitle" class="articleTitle text-color text-body-1">{{ item.title }}</span>
+      <span v-if="showArticleTitle" class="articleTitle text-color text-body">{{ item.title }}</span>
       <div class="articlePostTitle">
-        <div class="reactions">
+        <div class="reactions text-subtitle">
           <v-icon
             v-if="showArticleDate"
             class="reactionIconStyle me-1"

--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsListTemplateViewItem.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsListTemplateViewItem.vue
@@ -36,8 +36,11 @@
         class="text-body">{{ item.title }}</span>
       <span
         v-if="showArticleSummary"
-        :class="extraClass">{{ item?.properties?.summary }}</span>
-      <div class="d-flex">
+        :class="extraClass"
+        class="text-subtitle">
+        {{ item?.properties?.summary }}
+      </span>
+      <div class="d-flex text-subtitle">
         <span v-if="showArticleAuthor" class="article-preTitle">{{ item.authorDisplayName }}</span>
         <v-icon
           v-if="showArticleSpace && showArticleAuthor"
@@ -47,7 +50,7 @@
         </v-icon>
         <span v-if="showArticleSpace" class="article-preTitle">{{ item.spaceDisplayName }}</span>
       </div>
-      <div class="article-postTitle">
+      <div class="text-no-wrap text-truncate d-flex text-subtitle">
         <span class="article-date me-2">
           <div v-if="showArticleDate" class="flex-column">
             <date-format
@@ -56,15 +59,15 @@
           </div>
         </span>
         <div v-if="showArticleReactions" class="reactions">
-          <v-icon class="reactions-icon-style me-1" size="12">
+          <v-icon class="me-1" size="12">
             mdi-thumb-up
           </v-icon>
           <div class="likes-count me-2">{{ item.likesCount }}</div>
-          <v-icon class="reactions-icon-style me-1" size="12">
+          <v-icon class="me-1" size="12">
             mdi-comment
           </v-icon>
           <div class="comments-count me-2">{{ item.commentsCount }}</div>
-          <v-icon class="reactions-icon-style me-1" size="12">
+          <v-icon class="me-1" size="12">
             mdi-eye
           </v-icon>
           <div class="viewCount">{{ item.viewsCount }}</div>           


### PR DESCRIPTION
Prior to this change, new list templates doesn't get styling from text styles of layout option, This PR makes sure to use the proper text classes to inherit styles from layout