### PR TITLE
fix: Enhance newsList templates styles for better compatibly with layout options - MEED-8704_MEED-8711 - Meeds-io/meeds#3200

### DIFF
--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsAlertView.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsAlertView.vue
@@ -28,7 +28,7 @@
         <div class="px-3">
           <v-icon color="white">warning</v-icon>
         </div>
-        <span class="d-none d-md-block ms-n1 pe-4 font-weight-bold text-uppercase" v-if="showHeader">{{ headerTitle }}</span>
+        <span class="d-none d-md-block ms-n1 pe-4 font-weight-bold" v-if="showHeader">{{ headerTitle }}</span>
       </div>
 
       <div class="alerts-viewer ps-5 flex-grow-1">

--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsCardsViewItem.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsCardsViewItem.vue
@@ -64,7 +64,7 @@
             </div>
                 
           </div>
-          <div v-if="showArticleSummary" class="d-flex text-color mt-4 text-subtitle"> {{ item?.properties?.summary }} </div>
+          <div v-if="showArticleSummary" class="d-flex mt-4 text-subtitle"> {{ item?.properties?.summary }} </div>
           <div class="mt-2 align-self-center text-subtitle font-weight-bold primary--text">{{ $t('news.cards.readMore') }}</div>
         </a>
       </div>

--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsListTemplateViewItem.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsListTemplateViewItem.vue
@@ -40,15 +40,14 @@
         class="text-subtitle">
         {{ item?.properties?.summary }}
       </span>
-      <div class="d-flex text-subtitle">
-        <span v-if="showArticleAuthor" class="article-preTitle">{{ item.authorDisplayName }}</span>
+      <div class="d-flex align-center text-subtitle mb-1">
+        <span v-if="showArticleAuthor">{{ item.authorDisplayName }}</span>
         <v-icon
           v-if="showArticleSpace && showArticleAuthor"
-          class="mx-1"
           small>
           mdi-chevron-right
         </v-icon>
-        <span v-if="showArticleSpace" class="article-preTitle">{{ item.spaceDisplayName }}</span>
+        <span v-if="showArticleSpace">{{ item.spaceDisplayName }}</span>
       </div>
       <div class="text-no-wrap text-truncate d-flex text-subtitle">
         <span class="article-date me-2">


### PR DESCRIPTION
1- Remove text transformation from alert template text header 
2 - Align icons in cards template
3 - Fix text summary applied color option