### PR TITLE
fix: Allow space publisher to add and edit news list portlet header translation - MEED-8568 - Meeds-io/meeds#3079

### DIFF
--- a/content-service/src/main/java/io/meeds/news/plugin/NewsListViewTranslationPlugin.java
+++ b/content-service/src/main/java/io/meeds/news/plugin/NewsListViewTranslationPlugin.java
@@ -19,11 +19,16 @@
  */
 package io.meeds.news.plugin;
 
+import io.meeds.news.service.NewsService;
+import io.meeds.news.utils.NewsUtils;
+import io.meeds.social.cms.service.CMSService;
 import io.meeds.social.translation.plugin.TranslationPlugin;
 import io.meeds.social.translation.service.TranslationService;
 import jakarta.annotation.PostConstruct;
 import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
+import org.exoplatform.commons.api.settings.SettingService;
+import org.exoplatform.commons.api.settings.SettingValue;
 import org.exoplatform.commons.exception.ObjectNotFoundException;
 import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.services.organization.OrganizationService;
@@ -34,16 +39,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
-import java.util.Objects;
 
 @Component
 public class NewsListViewTranslationPlugin extends TranslationPlugin {
 
   public static final String        NEWS_LIST_VIEW_OBJECT_TYPE      = "newsListView";
-
-  private static final String       PUBLISHER_MEMBERSHIP_NAME       = "publisher";
-
-  private static final String       PLATFORM_WEB_CONTRIBUTORS_GROUP = "/platform/web-contributors";
+  
 
   @Setter
   private IdentityRegistry    identityRegistry;
@@ -53,6 +54,15 @@ public class NewsListViewTranslationPlugin extends TranslationPlugin {
 
   @Autowired
   private TranslationService  translationService;
+
+  @Autowired
+  private CMSService          cmsService;
+
+  @Autowired
+  private SettingService      settingService;
+
+  @Autowired
+  private NewsService         newsService;
 
   @PostConstruct
   public void init() {
@@ -78,8 +88,12 @@ public class NewsListViewTranslationPlugin extends TranslationPlugin {
   @Override
   public boolean hasEditPermission(long objectId, String username) {
     try {
+      SettingValue<?> settingNameValue = settingService.get(NewsUtils.NEWS_LIST_VIEW_CONTEXT,
+                                                            NewsUtils.NEWS_LIST_VIEW_SCOPE,
+                                                            String.valueOf(objectId));
+      String settingName = settingNameValue != null ? settingNameValue.getValue().toString() : null;
       return getIdentity(username) != null
-          && Objects.requireNonNull(getIdentity(username)).isMemberOf(PLATFORM_WEB_CONTRIBUTORS_GROUP, PUBLISHER_MEMBERSHIP_NAME);
+          && (cmsService.hasEditPermission(getIdentity(username), "newsListViewPortlet", settingName));
     } catch (Exception e) {
       return false;
     }

--- a/content-service/src/main/java/io/meeds/news/utils/NewsUtils.java
+++ b/content-service/src/main/java/io/meeds/news/utils/NewsUtils.java
@@ -29,6 +29,8 @@ import io.meeds.notes.model.NotePageProperties;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 
+import org.exoplatform.commons.api.settings.data.Context;
+import org.exoplatform.commons.api.settings.data.Scope;
 import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.commons.utils.ListAccess;
 import org.exoplatform.container.ExoContainerContext;
@@ -96,7 +98,15 @@ public class NewsUtils {
 
   public static final String CREATE_PUBLISH_CONTENT          = "createPublishContent";
 
-  public static final String UPDATE_PUBLISH_CONTENT          = "updatePublishContent";
+  public static final String  UPDATE_PUBLISH_CONTENT        = "updatePublishContent";
+
+  public static final String  NEWS_LIST_VIEW_SCOPE_NAME     = "NEWS_LIST_VIEW_SCOPE";
+
+  public static final String  NEWS_LIST_VIEW_CONTEXT_NAME   = "NEWS_LIST_VIEW_CONTEXT";
+
+  public static final Context NEWS_LIST_VIEW_CONTEXT        = Context.GLOBAL.id(NEWS_LIST_VIEW_CONTEXT_NAME);
+
+  public static final Scope   NEWS_LIST_VIEW_SCOPE          = Scope.APPLICATION.id(NEWS_LIST_VIEW_SCOPE_NAME);
 
 
   private static SpaceService       spaceService;

--- a/content-webapp/src/main/java/io/meeds/news/portlet/NewsListViewPortlet.java
+++ b/content-webapp/src/main/java/io/meeds/news/portlet/NewsListViewPortlet.java
@@ -31,15 +31,21 @@ import javax.portlet.PortletPreferences;
 import javax.portlet.RenderRequest;
 import javax.portlet.RenderResponse;
 
+import io.meeds.news.utils.NewsUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import io.meeds.social.portlet.CMSPortlet;
+import org.exoplatform.commons.api.settings.SettingService;
+import org.exoplatform.commons.api.settings.SettingValue;
+import org.exoplatform.container.ExoContainerContext;
 
 public class NewsListViewPortlet extends CMSPortlet {
 
   private static final String OBJECT_TYPE    = "newsListViewPortlet";
 
   private static final String APPLICATION_ID = "applicationId";
+
+  private SettingService settingService;
 
   @Override
   public void init(PortletConfig config) throws PortletException {
@@ -64,8 +70,10 @@ public class NewsListViewPortlet extends CMSPortlet {
 
   @Override
   public void doView(RenderRequest request, RenderResponse response) throws PortletException, IOException {
-    request.setAttribute(APPLICATION_ID, getOrCreateApplicationId(request.getPreferences()));
     super.doView(request, response);
+    String applicationId = getOrCreateApplicationId(request.getPreferences());
+    request.setAttribute(APPLICATION_ID, applicationId);
+    initNewsListHeaderTranslationSettings(request);
   }
 
   private String getOrCreateApplicationId(PortletPreferences preferences) {
@@ -76,5 +84,27 @@ public class NewsListViewPortlet extends CMSPortlet {
       savePreference(APPLICATION_ID, applicationId);
     }
     return applicationId;
+  }
+
+  private void initNewsListHeaderTranslationSettings(RenderRequest request) {
+    String applicationId = request.getAttribute(APPLICATION_ID).toString();
+    String settingName = request.getAttribute("settingName").toString();
+    SettingValue<?> storedSettingNameValue = getSettingService().get(NewsUtils.NEWS_LIST_VIEW_CONTEXT,
+                                                                     NewsUtils.NEWS_LIST_VIEW_SCOPE,
+                                                                     applicationId);
+    String storedSettingName = storedSettingNameValue != null ? storedSettingNameValue.getValue().toString() : null;
+    if (storedSettingName == null || !storedSettingName.equals(settingName)) {
+      getSettingService().set(NewsUtils.NEWS_LIST_VIEW_CONTEXT,
+                              NewsUtils.NEWS_LIST_VIEW_SCOPE,
+                              applicationId,
+                              SettingValue.create(settingName));
+    }
+  }
+
+  private SettingService getSettingService() {
+    if (settingService == null) {
+      settingService = ExoContainerContext.getService(SettingService.class);
+    }
+    return settingService;
   }
 }


### PR DESCRIPTION
Before this change, only Web Contributors were able to create and edit the News List portlet header translation. This update modifies the portlet doView to store the applicationId and settingName properties as general portlet context and scope settings in key-value format, using them in the translation plugin to compute the correct permissions.
Resolves https://github.com/Meeds-io/meeds/issues/3079