### PR TITLE
fix: Spaces should be unselected by default in news app filter - MEED-8648 - Meeds-io/meeds#2856

### DIFF
--- a/content-webapp/src/main/webapp/vue-app/news/components/NewsApp.vue
+++ b/content-webapp/src/main/webapp/vue-app/news/components/NewsApp.vue
@@ -220,7 +220,7 @@ export default {
       handler: function () {
         this.fetchNews(false);
         if (this.spacesFilter === false) {
-          this.spacesFilter = ['-1'];
+          this.spacesFilter = [];
         }
         if (this.spacesFilter.length > 0) {
           window.history.pushState('', 'News', this.setQueryParam('spaces', this.spacesFilter.toString().replace(/,/g, '_')));

--- a/content-webapp/src/main/webapp/vue-app/news/components/NewsFilterSpaceDrawer.vue
+++ b/content-webapp/src/main/webapp/vue-app/news/components/NewsFilterSpaceDrawer.vue
@@ -71,7 +71,7 @@ export default {
     open() {
       this.$refs.newsSpacesFilters.open();
       this.$nextTick().then(() => {
-        this.$refs.filterSpaceList.reset();
+        this.$refs.filterSpaceList?.reset();
       });
     },
   },

--- a/content-webapp/src/main/webapp/vue-app/news/components/NewsFilterSpaceList.vue
+++ b/content-webapp/src/main/webapp/vue-app/news/components/NewsFilterSpaceList.vue
@@ -76,7 +76,7 @@ export default {
   data: () => ({
     spaces: [],
     selectionType: 'all',
-    selectAll: true,
+    selectAll: false,
     loading: false,
     query: null,
     limit: 20,
@@ -137,7 +137,7 @@ export default {
       if (!this.spaces || !this.spaces.length) {
         this.retrieveSpaces();
       }
-      this.selectAll = !this.value || !this.value.length;
+      this.selectAll = this.spaceIds.length === this.selectedSpaces.length;
       window.setTimeout(() => this.$refs.queryInput.$el.querySelector('input').focus(), 200);
     },
     loadMore() {
@@ -190,7 +190,7 @@ export default {
         } else {
           this.spaces = [];
         }
-        if (this.value === false) {
+        if (!this.value || !this.selectAll) {
           this.uncheckAll();
         } else if (!this.value || !this.value.length) {
           this.selectedSpaces = this.spaces.slice();


### PR DESCRIPTION
Spaces should be unselected by default in news app filter