### PR TITLE
fix: News Publish drawer - infinite save button loading - EXO-78154 - Meeds-io/meeds#3184

### DIFF
--- a/content-webapp/src/main/webapp/vue-app/news-details/components/ExoNewsDetails.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-details/components/ExoNewsDetails.vue
@@ -355,15 +355,17 @@ export default {
           this.redirectToDrafts();
         });
       } else {
+        const successMessage = this.$t('notes.publication.settings.update.success');
+        const errorMessage = this.$t('notes.publication.settings.update.error');
+        document.dispatchEvent(new Event('closeDisplayedDrawer'));
         this.publish(editScheduleAction, scheduleSettings).then((article) => {
-          this.displayMessage({message: this?.$t?.('notes.publication.settings.update.success'), type: 'success'});
+          this.displayMessage({message: successMessage, type: 'success'});
           history.replaceState({}, article.url);
           this.news = article;
         }).catch(() => {
-          this.displayMessage({message: this?.$t?.('notes.publication.settings.update.error'), type: 'error'});
+          this.displayMessage({message: errorMessage, type: 'error'});
         }).finally(() => {
           this.isPublishing = false;
-          this.$refs?.publicationDrawer?.close();
         });
       }
     },


### PR DESCRIPTION
Prior to this change, when create article in spacex and publish it in the news list target space then open menu action of that news and click on publish disable toggle button publish in news list then click on save, the page is blocked and save button keeps on loading. To fix this problem, close the publicationDrawer drawer before running the save request. After this change, save is done with no issues.

(cherry picked from commit dc8977ad4c84851a968a076a6f9d3a8223131798)