### PR TITLE
fix: Add missing translationField amd module to newsListView portlet - MEED-8602 - Meeds-io/meeds#3114

### DIFF
--- a/content-webapp/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/content-webapp/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -232,6 +232,9 @@
       <depends>
         <module>commonVueComponents</module>
       </depends>
+      <depends>
+        <module>translationField</module>
+      </depends>
     </module>
   </portlet>
 


### PR DESCRIPTION
Add missing translationField amd module to newsListView portlet