### PR TITLE
fix: error when unpublishing scheduled article - MEED-8714 - Meeds-io/meeds#3149

### DIFF
--- a/content-service/src/main/java/io/meeds/news/listener/NewsActivityListener.java
+++ b/content-service/src/main/java/io/meeds/news/listener/NewsActivityListener.java
@@ -157,14 +157,22 @@ public class NewsActivityListener extends ActivityListenerPlugin {
   }
 
   private String getCurrentIdentityId() {
-    org.exoplatform.services.security.Identity currentIdentity = ConversationState.getCurrent().getIdentity();
-    return identityManager.getOrCreateUserIdentity(currentIdentity.getUserId()).getId();
+    ConversationState conversationState = ConversationState.getCurrent();
+    org.exoplatform.services.security.Identity currentIdentity = null;
+    if (conversationState != null) {
+      currentIdentity = conversationState.getIdentity();
+    }
+    if (currentIdentity != null) {
+      return identityManager.getOrCreateUserIdentity(currentIdentity.getUserId()).getId();
+    }
+    return null;
   }
 
   private void updateNewsPageMetadataObjectItem(ExoSocialActivity activity) {
     String newsId = activity.getTemplateParams().get(NEWS_ID);
     String spaceId = activity.getSpaceId();
     String currentIdentityId = getCurrentIdentityId();
+    long updater = currentIdentityId != null ? Long.parseLong(currentIdentityId) : Long.parseLong(activity.getPosterId());
     NewsPageObject newsPageObject = new NewsPageObject(NEWS_METADATA_PAGE_OBJECT_TYPE, newsId, null, Long.parseLong(spaceId));
     MetadataItem metadataItem = metadataService.getMetadataItemsByMetadataAndObject(NEWS_METADATA_KEY, newsPageObject)
                                                .stream()
@@ -177,7 +185,7 @@ public class NewsActivityListener extends ActivityListenerPlugin {
       if (properties.containsKey(NEWS_ACTIVITY_POSTED) && properties.get(NEWS_ACTIVITY_POSTED) != null && Boolean.parseBoolean(properties.get(NEWS_ACTIVITY_POSTED))) {
         properties.put(NEWS_ACTIVITY_POSTED, String.valueOf(false));
         metadataItem.setProperties(properties);
-        metadataService.updateMetadataItem(metadataItem, Long.parseLong(currentIdentityId), false);
+        metadataService.updateMetadataItem(metadataItem, updater, false);
       }
     }
   }

--- a/content-service/src/main/java/io/meeds/news/service/impl/NewsServiceImpl.java
+++ b/content-service/src/main/java/io/meeds/news/service/impl/NewsServiceImpl.java
@@ -452,7 +452,11 @@ public class NewsServiceImpl implements NewsService {
   public void unpublishNews(String newsId, String publisher, boolean unpublishScheduled) throws Exception {
     News news = getNewsArticleById(newsId);
     Space space = spaceService.getSpaceById(news.getSpaceId());
-    newsTargetingService.deleteNewsTargets(news, publisher);
+    if (unpublishScheduled) {
+      newsTargetingService.deleteNewsTargets(news);
+    } else {
+      newsTargetingService.deleteNewsTargets(news, publisher);
+    }
 
     NewsPageObject newsPageObject = new NewsPageObject(NEWS_METADATA_PAGE_OBJECT_TYPE,
                                                        news.getId(),


### PR DESCRIPTION
Prior to this change, the scheduled unpublishing of an article did not work, and the article remained published. This issue was caused by a NullPointerException during the fetch of the identity and an IllegalAccessException during the deletion of the article targets. This change handles these exceptions.
Resolves https://github.com/Meeds-io/meeds/issues/3194