### PR TITLE
fix: Content translation draft not deleted from news delete action - MEED-8741 - Meeds-io/meeds#3213

### DIFF
--- a/content-service/src/main/java/io/meeds/news/service/impl/NewsServiceImpl.java
+++ b/content-service/src/main/java/io/meeds/news/service/impl/NewsServiceImpl.java
@@ -370,18 +370,6 @@ public class NewsServiceImpl implements NewsService {
     }
     if (NewsObjectType.DRAFT.name().toLowerCase().equals(newsObjectType)) {
       deleteDraftArticle(newsId, currentIdentity.getUserId());
-    } else if (LATEST_DRAFT.name().toLowerCase().equals(newsObjectType)) {
-      Page newsArticlePage = noteService.getNoteById(newsId);
-      if (newsArticlePage != null) {
-        DraftPage draft = noteService.getLatestDraftPageByUserAndTargetPageAndLang(Long.parseLong(newsArticlePage.getId()),
-                                                                                   currentIdentity.getUserId(),
-                                                                                   null);
-        if (draft != null) {
-          // check if the latest draft has the same illustration
-          // with the news article to do not remove it.
-          deleteDraftArticle(draft.getId(), currentIdentity.getUserId());
-        }
-      }
     } else {
       deleteArticle(news, currentIdentity.getUserId());
       if (news.getActivities() != null) {
@@ -1671,7 +1659,6 @@ public class NewsServiceImpl implements NewsService {
                             try {
                               News draft = buildDraftArticle(draftArticle.getObjectId(), currentIdentity.getUserId());
                               if (draft != null && draftArticle.getParentObjectId() != null) {
-                                draft.setId(draftArticle.getParentObjectId());
                                 News parentArticle = buildArticle(draftArticle.getParentObjectId(), draft.getLang(), true);
                                 draft.setReferred(parentArticle.isReferred());
                                 draft.setFromExternalPage(parentArticle.isFromExternalPage());

--- a/content-webapp/src/main/webapp/vue-app/news/components/NewsApp.vue
+++ b/content-webapp/src/main/webapp/vue-app/news/components/NewsApp.vue
@@ -406,11 +406,7 @@ export default {
       const redirectionTime = 8100;
       let newsObjectType;
       if (this.newsFilter === 'drafts') {
-        if (news.activityId) {
-          newsObjectType = 'latest_draft';
-        } else {
-          newsObjectType = 'draft';
-        }
+        newsObjectType = 'draft';
       } else  {
         newsObjectType = 'article';
       }


### PR DESCRIPTION
Prior to this change, the content translation draft was not deleted when using the delete action from the News app’s action menu. This was because the delete logic was implemented to remove only the draft of the existing page without a language. This change ensures that the draft is deleted by its ID, regardless of the language.
Resolves https://github.com/Meeds-io/meeds/issues/3213