### PR TITLE
fix: Original draft of existing article opened instead of the specific lang draft - MEED-8794 - Meeds-io/meeds#3220

### DIFF
--- a/content-webapp/src/main/webapp/vue-app/news/components/NewsApp.vue
+++ b/content-webapp/src/main/webapp/vue-app/news/components/NewsApp.vue
@@ -312,6 +312,9 @@ export default {
         draftUrl += `&spaceName=${item.spaceUrl.substring(item.spaceUrl.lastIndexOf('/') + 1)}`;
       }
       draftUrl += `&type=${(item.activityId || item.schedulePostDate) && 'latest_draft' || 'draft'}`;
+      if (item.lang) {
+        draftUrl += `&lang=${item.lang}`;
+      }
       return draftUrl;
     },
     getNewsText(newsSummary, newsBody) {
@@ -358,6 +361,8 @@ export default {
           spaceAvatarUrl: item.spaceAvatarUrl,
           hiddenSpace: item.hiddenSpace,
           spaceId: item.spaceId,
+          lang: item.lang,
+          targetPageId: item.targetPageId,
           target: this.newsFilter === 'drafts' ? '_blank' : '_self',
           type: this.newsFilter === 'drafts' ? 'draft' : 'article'
         });


### PR DESCRIPTION

Prior to this change, drafts without a language were opened from the news app's edit action menu instead of the specific language. This issue was due to missing properties used in the construction of the news URL. This change adds those properties.
Resolves https://github.com/Meeds-io/meeds/issues/3220