### PR TITLE
fix: incorrect post and publish notification URL redirection after updating the server domain name - MEED-8761 - Meeds-io/meeds#2871

### DIFF
--- a/content-service/src/main/java/io/meeds/news/notification/utils/NotificationUtils.java
+++ b/content-service/src/main/java/io/meeds/news/notification/utils/NotificationUtils.java
@@ -47,8 +47,7 @@ public class NotificationUtils {
     } else {
       activityLink = getNotificationActivityLinkForNotSpaceMembers(space);
     }
-    String baseUrl = PropertyManager.getProperty("gatein.email.domain.url");
-    return baseUrl == null ? activityLink : baseUrl.concat(activityLink);
+    return activityLink;
   }
 
   public static String getNotificationActivityLinkForNotSpaceMembers(Space space) {

--- a/content-service/src/main/java/io/meeds/news/service/impl/NewsServiceImpl.java
+++ b/content-service/src/main/java/io/meeds/news/service/impl/NewsServiceImpl.java
@@ -46,6 +46,7 @@ import io.meeds.news.model.*;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.exoplatform.social.core.service.LinkProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
@@ -1747,7 +1748,7 @@ public class NewsServiceImpl implements NewsService {
       throw new NullPointerException("Cannot find a space with id " + contentSpaceId + ", it may not exist");
     }
     org.exoplatform.social.core.identity.model.Identity identity = identityManager.getOrCreateUserIdentity(contentAuthor);
-    String authorAvatarUrl = LinkProviderUtils.getUserAvatarUrl(identity.getProfile());
+    String authorAvatarUrl = (identity.getProfile() != null && identity.getProfile().getAvatarUrl() != null) ? identity.getProfile().getAvatarUrl() : LinkProvider.PROFILE_DEFAULT_AVATAR_URL;
     String activityLink = NotificationUtils.getNotificationActivityLink(contentSpace, contentActivityId, canView);
     String contentSpaceName = contentSpace.getDisplayName();
 

--- a/content-service/src/test/java/io/meeds/news/notification/utils/NotificationUtilsTest.java
+++ b/content-service/src/test/java/io/meeds/news/notification/utils/NotificationUtilsTest.java
@@ -58,12 +58,11 @@ public class NotificationUtilsTest {
     space1.setPrettyName("space1");
     space1.setGroupId("space1");
     PORTAL_CONTAINER.when(() -> PortalContainer.getCurrentPortalContainerName()).thenReturn("portal");
-    PROPERTY_MANAGER.when(() -> PropertyManager.getProperty("gatein.email.domain.url")).thenReturn("http://localhost:8080");
 
     // When
     String activityUrl = NotificationUtils.getNotificationActivityLink(space1, "13", false);
 
-    assertEquals("http://localhost:8080/portal/s/" + space1.getId(), activityUrl);
+    assertEquals("/portal/s/" + space1.getId(), activityUrl);
   }
 
   @Test
@@ -76,18 +75,16 @@ public class NotificationUtilsTest {
     space.setGroupId("space1");
 
     PORTAL_CONTAINER.when(() -> PortalContainer.getCurrentPortalContainerName()).thenReturn("portal");
-    PROPERTY_MANAGER.when(() -> PropertyManager.getProperty("gatein.email.domain.url")).thenReturn("http://localhost:8080");
-
     // When
     String activityUrl = NotificationUtils.getNotificationActivityLink(space, "13", false);
 
-    assertEquals("http://localhost:8080/portal/s/" + space.getId(), activityUrl);
+    assertEquals("/portal/s/" + space.getId(), activityUrl);
 
     Space updatedSpace = space;
     updatedSpace.setDisplayName("Space One");
     updatedSpace.setPrettyName(updatedSpace.getDisplayName());
 
     activityUrl = NotificationUtils.getNotificationActivityLink(updatedSpace, "13", false);
-    assertEquals("http://localhost:8080/portal/s/" + updatedSpace.getId(), activityUrl);
+    assertEquals("/portal/s/" + updatedSpace.getId(), activityUrl);
   }
 }

--- a/content-webapp/src/main/webapp/vue-app/news-extensions/notification-extensions/components/PostNewsNotificationPlugin.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-extensions/notification-extensions/components/PostNewsNotificationPlugin.vue
@@ -44,14 +44,20 @@ export default {
   },
   computed: {
     url() {
-      return this.notification?.space?.isMember ? this.notification?.parameters?.ACTIVITY_LINK
+      let activityLink = this.notification?.parameters?.ACTIVITY_LINK;
+      // work around for the case when activity url include the domain name
+      activityLink = activityLink.substring(activityLink.indexOf(eXo.env.portal.context));
+      return this.notification?.space?.isMember ? activityLink
         : `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/news-detail?newsId=${this.notification?.parameters?.NEWS_ID}&type=article`;
     },
     eventTitle() {
       return this.notification?.parameters?.CONTENT_TITLE;
     },
     avatarUrl() {
-      return this.notification?.parameters?.AUTHOR_AVATAR_URL;
+      let avatarUrl = this.notification?.parameters?.AUTHOR_AVATAR_URL;
+      // work around for the case when avatarUrl include the domain name
+      avatarUrl = avatarUrl.substring(avatarUrl.indexOf(eXo.env.portal.context));
+      return avatarUrl;
     },
     message() {
       let message;


### PR DESCRIPTION

Prior to this change, after updating the server domain name, the post and publish article notifications still redirected to the old domain. This issue was caused by the activityLink notification parameter, which included the server domain name. This change removes the domain name from the notification URL to prevent such issues.