### PR TITLE
feat: Enhance Service Spring Bean definition - Meeds-io/MIPs#191

### DIFF
--- a/content-service/src/main/java/io/meeds/content/image/plugin/ImagePortletInstancePreferencePlugin.java
+++ b/content-service/src/main/java/io/meeds/content/image/plugin/ImagePortletInstancePreferencePlugin.java
@@ -27,10 +27,12 @@ import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
 
 import org.exoplatform.commons.file.model.FileItem;
 import org.exoplatform.commons.file.services.FileService;
+import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.portal.config.model.Application;
 import org.exoplatform.portal.pom.spi.portlet.Portlet;
 import org.exoplatform.portal.pom.spi.portlet.Preference;
@@ -39,26 +41,40 @@ import org.exoplatform.social.attachment.AttachmentService;
 import io.meeds.layout.model.PortletInstanceContext;
 import io.meeds.layout.model.PortletInstancePreference;
 import io.meeds.layout.plugin.PortletInstancePreferencePlugin;
+import io.meeds.layout.service.PortletInstanceService;
 import io.meeds.social.cms.model.CMSSetting;
 import io.meeds.social.cms.service.CMSService;
 
+import jakarta.annotation.PostConstruct;
 import lombok.SneakyThrows;
 
-@Service
+@Component
+@Profile("layout")
 public class ImagePortletInstancePreferencePlugin implements PortletInstancePreferencePlugin {
 
-  private static final String CMS_SETTING_PREFERENCE_NAME = "name";
+  private static final String    CMS_SETTING_PREFERENCE_NAME = "name";
 
-  private static final String DATA_INIT_PREFERENCE_NAME   = "data.init";
-
-  @Autowired
-  private AttachmentService   attachmentService;
+  private static final String    DATA_INIT_PREFERENCE_NAME   = "data.init";
 
   @Autowired
-  private CMSService          cmsService;
+  private AttachmentService      attachmentService;
 
   @Autowired
-  private FileService         fileService;
+  private CMSService             cmsService;
+
+  @Autowired
+  private FileService            fileService;
+
+  @Autowired(required = false)
+  private PortletInstanceService portletInstanceService;
+
+  @PostConstruct
+  public void init() {
+    if (portletInstanceService == null) {
+      portletInstanceService = ExoContainerContext.getService(PortletInstanceService.class);
+    }
+    portletInstanceService.addPortletInstancePreferencePlugin(this);
+  }
 
   @Override
   public String getPortletName() {
@@ -67,7 +83,9 @@ public class ImagePortletInstancePreferencePlugin implements PortletInstancePref
 
   @Override
   @SneakyThrows
-  public List<PortletInstancePreference> generatePreferences(Application application, Portlet preferences, PortletInstanceContext portletInstanceContext) {
+  public List<PortletInstancePreference> generatePreferences(Application application,
+                                                             Portlet preferences,
+                                                             PortletInstanceContext portletInstanceContext) {
     String settingName = getCmsSettingName(preferences);
     if (StringUtils.isBlank(settingName)) {
       if (preferences != null && preferences.getPreference(DATA_INIT_PREFERENCE_NAME) != null) {

--- a/content-service/src/main/java/io/meeds/content/link/plugin/LinkPortletInstancePreferencePlugin.java
+++ b/content-service/src/main/java/io/meeds/content/link/plugin/LinkPortletInstancePreferencePlugin.java
@@ -23,8 +23,10 @@ import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
 
+import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.portal.config.model.Application;
 import org.exoplatform.portal.pom.spi.portlet.Portlet;
 import org.exoplatform.portal.pom.spi.portlet.Preference;
@@ -34,19 +36,33 @@ import io.meeds.content.link.service.LinkService;
 import io.meeds.layout.model.PortletInstanceContext;
 import io.meeds.layout.model.PortletInstancePreference;
 import io.meeds.layout.plugin.PortletInstancePreferencePlugin;
+import io.meeds.layout.service.PortletInstanceService;
 import io.meeds.social.util.JsonUtils;
 
+import jakarta.annotation.PostConstruct;
 import lombok.SneakyThrows;
 
-@Service
+@Component
+@Profile("layout")
 public class LinkPortletInstancePreferencePlugin implements PortletInstancePreferencePlugin {
 
-  private static final String CMS_SETTING_PREFERENCE_NAME = "name";
+  private static final String    CMS_SETTING_PREFERENCE_NAME = "name";
 
-  private static final String DATA_INIT_PREFERENCE_NAME   = "data.init";
+  private static final String    DATA_INIT_PREFERENCE_NAME   = "data.init";
 
   @Autowired
-  private LinkService         linkService;
+  private LinkService            linkService;
+
+  @Autowired(required = false)
+  private PortletInstanceService portletInstanceService;
+
+  @PostConstruct
+  public void init() {
+    if (portletInstanceService == null) {
+      portletInstanceService = ExoContainerContext.getService(PortletInstanceService.class);
+    }
+    portletInstanceService.addPortletInstancePreferencePlugin(this);
+  }
 
   @Override
   public String getPortletName() {
@@ -55,7 +71,9 @@ public class LinkPortletInstancePreferencePlugin implements PortletInstancePrefe
 
   @Override
   @SneakyThrows
-  public List<PortletInstancePreference> generatePreferences(Application application, Portlet preferences, PortletInstanceContext portletInstanceContext) {
+  public List<PortletInstancePreference> generatePreferences(Application application,
+                                                             Portlet preferences,
+                                                             PortletInstanceContext portletInstanceContext) {
     String settingName = getCmsSettingName(preferences);
     if (StringUtils.isBlank(settingName)) {
       if (preferences != null && preferences.getPreference(DATA_INIT_PREFERENCE_NAME) != null) {

--- a/content-service/src/main/java/io/meeds/content/link/storage/cache/CachedLinkStorage.java
+++ b/content-service/src/main/java/io/meeds/content/link/storage/cache/CachedLinkStorage.java
@@ -52,9 +52,9 @@ public class CachedLinkStorage extends LinkStorage {
       @Override
       public LinkSetting retrieve(Object context, Serializable key) throws Exception {
         return switch (key) {
-          case String name -> CachedLinkStorage.super.getLinkSetting(name);
-          case Long id -> CachedLinkStorage.super.getLinkSetting(id);
-          default -> null;
+        case String name -> CachedLinkStorage.super.getLinkSetting(name);
+        case Long id -> CachedLinkStorage.super.getLinkSetting(id);
+        default -> null;
         };
       }
     };

--- a/content-service/src/main/java/io/meeds/content/news/plugin/NewsPermanentLinkPlugin.java
+++ b/content-service/src/main/java/io/meeds/content/news/plugin/NewsPermanentLinkPlugin.java
@@ -19,7 +19,7 @@
 package io.meeds.content.news.plugin;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 
 import org.exoplatform.commons.exception.ObjectNotFoundException;
 import org.exoplatform.portal.config.UserPortalConfigService;
@@ -29,11 +29,14 @@ import io.meeds.content.news.model.News;
 import io.meeds.content.news.service.NewsService;
 import io.meeds.portal.permlink.model.PermanentLinkObject;
 import io.meeds.portal.permlink.plugin.PermanentLinkPlugin;
+import io.meeds.portal.permlink.service.PermanentLinkService;
+
+import jakarta.annotation.PostConstruct;
 
 /**
  * A plugin to generate a permanent link for a given news identified by its id
  */
-@Service
+@Component
 public class NewsPermanentLinkPlugin implements PermanentLinkPlugin {
 
   public static final String      OBJECT_TYPE = "news";
@@ -45,6 +48,9 @@ public class NewsPermanentLinkPlugin implements PermanentLinkPlugin {
 
   @Autowired
   private NewsService             newsService;
+
+  @Autowired
+  private PermanentLinkService    permanentLinkService;
 
   @Override
   public String getObjectType() {
@@ -61,6 +67,11 @@ public class NewsPermanentLinkPlugin implements PermanentLinkPlugin {
     String newsId = object.getObjectId();
     News news = newsService.getNewsArticleById(newsId);
     return String.format(URL_FORMAT, portalConfigService.getMetaPortal(), news.getActivityId());
+  }
+
+  @PostConstruct
+  public void init() {
+    permanentLinkService.addPlugin(this);
   }
 
 }


### PR DESCRIPTION
This change will change the definition of `PortletInstanceService` and `PermanentLinkService` plugins definition to make it included only after the '`content`' context is initialized rather than getting initialized when '`layout`' context is initialized which is done at first.