### PR TITLE
fix: Display problem with Headline Template in case of high resolution - MEED-8884 - Meeds-io/meeds#2677 

### DIFF
--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsLatestView.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsLatestView.vue
@@ -86,7 +86,9 @@ export default {
   },
   mounted() {
     this.$nextTick().then(() => this.$root.$emit('application-loaded'));
-    this.hasSmallWidthContainer = (this.$refs['news-latest-view']?.clientWidth *100 / window.screen.width) < 33;
+    const lgBreakpoint = this.$vuetify.breakpoint.thresholds.lg;
+    const screenWidth =  window.screen.width < lgBreakpoint ? window.screen.width : lgBreakpoint;
+    this.hasSmallWidthContainer = (this.$refs['news-latest-view']?.clientWidth *100 / screenWidth) < 33;
   },
 };
 </script>


### PR DESCRIPTION
Before this change, when open news list portlet on headline template using pc with high resolution (3 * the width of the column in which the news is displayed), the news list is displayed on mobile version while I am using a desktop view. To fix this problem, add a condition for high resolution screens to apply large resolution styles. After this change, news list portlet on headline template is displayed correctly of high resolution.

(cherry picked from commit 3f2f473c01d27faf4556980350817a61aaa62f37)