### PR TITLE
feat: Remove Referencing Notes Button - MEED-8933 - Meeds-io/MIPs#192

### DIFF
--- a/content-webapp/src/main/webapp/WEB-INF/conf/news/ckeditor/config.js
+++ b/content-webapp/src/main/webapp/WEB-INF/conf/news/ckeditor/config.js
@@ -30,7 +30,7 @@ CKEDITOR.editorConfig = function (config) {
     {name: 'links', items: ['Link', 'Anchor']},
     {
       name: 'blocks',
-      items: ['Blockquote', 'tagSuggester', 'emoji', 'selectImage', 'Table', 'EmbedSemantic', 'CodeSnippet', 'InsertOptions']
+      items: ['Blockquote', 'tagSuggester', 'emoji', 'selectImage', 'Table', 'EmbedSemantic', 'CodeSnippet']
     },
   ];
 
@@ -49,7 +49,7 @@ CKEDITOR.editorConfig = function (config) {
     {name: 'links', items: ['Link', 'Anchor']},
     {
       name: 'blocks',
-      items: ['Blockquote', 'tagSuggester', 'emoji', 'selectImage', 'Table', 'EmbedSemantic', 'InsertOptions']
+      items: ['Blockquote', 'tagSuggester', 'emoji', 'selectImage', 'Table', 'EmbedSemantic']
     },
   ];
 


### PR DESCRIPTION
This change will delete a button from Note Editor which was giving a way to including a note inside another one. This plugin will be replaced by another more generic feature allowing to reference objects/contents from RichEditor.