### PR TITLE
fix: Fix displaying published articles with "space" audience in news list portlets for admins not space members - MEED-9089 - Meeds-io/meeds#2794

### DIFF
--- a/content-service/src/main/java/io/meeds/content/news/service/NewsService.java
+++ b/content-service/src/main/java/io/meeds/content/news/service/NewsService.java
@@ -2213,8 +2213,7 @@ public class NewsService {
         news.setSpaceDisplayName(space.getDisplayName());
         boolean hiddenSpace = space.getVisibility().equals(Space.HIDDEN) && !spaceService.canViewSpace(space, currentUsername);
         news.setHiddenSpace(hiddenSpace);
-        boolean isSpaceMember = spaceService.canViewSpace(space, currentUsername);
-        news.setSpaceMember(isSpaceMember);
+        news.setSpaceMember(spaceService.isMember(space, currentUsername));
         if (StringUtils.isNotEmpty(space.getGroupId())) {
           news.setSpaceUrl(NewsUtils.buildSpaceUrl(space.getId()));
         }


### PR DESCRIPTION

Prior to this change, admins can see in the news list portlets all scheduled articles with "space" audience even if they are not members of the scheduled article space. This is due to the attribute "spaceMember" of News entity set to the space viewers (retrieved by spaceService.canViewSpace) which include super managers. After this commit, we ensure to set the attribute "spaceMember" of News entity to space members only in order to avoid viewing scheduled articles with "space" audience by admins.

Resolves https://github.com/Meeds-io/meeds/issues/2794