### PR TITLE
fix: Update crowdin.yml by adding Image_en.properties and Links_en.properties

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -55,4 +55,24 @@ files: [
     "escape_special_characters": 0,
     "escape_quotes" : 0,
   },
+  {
+    "source" : "/content-webapp/src/main/resources/locale/portlet/Links_en.properties",
+
+    "translation" : "%original_path%/%file_name%!_%locale_with_underscore%.%file_extension%",
+    "translation_replace" : {YML_CROWDIN_LANGUAGES_ARG},
+    "dest" : "hub/content/Links.properties",
+    "update_option" : "update_as_unapproved",
+    "escape_special_characters": 0,
+    "escape_quotes" : 0,
+  },
+  {
+    "source" : "/content-webapp/src/main/resources/locale/portlet/Image_en.properties",
+
+    "translation" : "%original_path%/%file_name%!_%locale_with_underscore%.%file_extension%",
+    "translation_replace" : {YML_CROWDIN_LANGUAGES_ARG},
+    "dest" : "hub/content/Image.properties",
+    "update_option" : "update_as_unapproved",
+    "escape_special_characters": 0,
+    "escape_quotes" : 0,
+  },
 ]


### PR DESCRIPTION
Since Links and Image portlets were moved from Social, the crowdin.yml had to be updated by referencing the associated I18N files.