### PR TITLE
fix: Set an empty alt to images of published and pinned article and to the avatar of whom pinned it - MEED-9151 - Meeds-io/meeds#3337

### DIFF
--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsCardsViewItem.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsCardsViewItem.vue
@@ -27,7 +27,7 @@
       <div class="imgContainer">
         <img
           :src="articleImage"
-          :alt="featuredImageAltText"
+          alt=""
           class="article-illustration-img">
       </div>
     </a>
@@ -44,7 +44,7 @@
             <img
               class="space-icon"
               :src="item.spaceAvatarUrl"
-              :alt="$t('news.space.icon.alt',{ 0:item.spaceDisplayName })">
+              alt="">
             <div class="space-name text-subtitle">{{ item.spaceDisplayName }}</div>
           </div>
         </a>

--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsLatestViewItem.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsLatestViewItem.vue
@@ -27,7 +27,7 @@
     <div class="articleImage" v-if="showImage">
       <img 
         :src="articleImg"
-        :alt="featuredImageAltText"
+        alt=""
         class="card-border-radius">
     </div>
     <div class="articleInfos">
@@ -35,7 +35,7 @@
         <img
           class="spaceImage"
           :src="item.spaceAvatarUrl"
-          :alt="$t('news.space.icon.alt',{ 0:item.spaceDisplayName })">
+          alt="">
         <span class="spaceName">{{ item.spaceDisplayName }}</span>
       </div>
       <span v-if="showArticleTitle" class="articleTitle text-color text-body">{{ item.title }}</span>

--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsListTemplateViewItem.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsListTemplateViewItem.vue
@@ -26,7 +26,7 @@
     <div v-if="showArticleImage" class="article-item-image">
       <img
         :src="articleImage"
-        :alt="featuredImageAltText"
+        alt=""
         class="card-border-radius">
     </div>
     <div class="article-item-content">

--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsMosaicView.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsMosaicView.vue
@@ -39,7 +39,7 @@
             :href="articleUrl(item)">
             <img
               :src="showArticleImage && item.illustrationURL !== null ? illustrationURL(item,index) : '/content/images/news.png'"
-              :alt="item?.properties?.featuredImage?.altText || $t('news.latest.alt.articleImage')"
+              alt=""
               class="card-border-radius">
             <div class="titleArea">
               <div v-if="showArticleDate" class="articleDate">

--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsSliderView.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsSliderView.vue
@@ -34,11 +34,13 @@
           class="carouselItem"
           eager
           dark>
-          <v-img
-            class="articleImage fill-height"
-            :src="showArticleImage && item.illustrationURL !== null ? item.illustrationURL.concat('&size=1420x222').toString() : '/content/images/news.png'"
-            :alt="item?.properties?.featuredImage?.altText"
-            eager />
+          <img
+            :src="showArticleImage && item.illustrationURL !== null
+              ? item.illustrationURL.concat('&size=1420x222')
+              : '/content/images/news.png'"
+            alt=""
+            class="articleImage object-fit-cover width-full full-height"
+          />
           <v-container class="slide-text-container d-flex text-center">
             <div class="flex flex-column carouselNewsInfo">
               <div

--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsSliderViewItem.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsSliderViewItem.vue
@@ -25,7 +25,7 @@
         <v-img
           class="author-image"
           :src="authorAvatarUrl"
-          :alt="$t('news.avatar.author.alt',{0:authorDisplayName})" />
+          alt="" />
       </v-avatar>
       <span class="text-capitalize text--white my-auto ml-2">{{ authorDisplayName }}</span>
     </div>
@@ -40,7 +40,7 @@
         <v-img
           class="spaceImage"
           :src="spaceAvatarUrl"
-          :alt="$t('news.space.icon.alt',{ 0:spaceDisplayName })" />
+          alt="" />
       </v-avatar>
       <a 
         :href="spaceUrl" 

--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsStoriesViewItem.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsStoriesViewItem.vue
@@ -32,13 +32,13 @@
         <img
           class="article-img"
           :src="articleImage"
-          :alt="$t('news.latest.alt.articleImage')">
+          alt="">
         <div class="author-date-container">
           <img
             v-if="showArticleAuthor"
             class="author-photo"
             :src="item.authorAvatarUrl"
-            :alt="$t('news.avatar.author.alt',{0:item.authorDisplayName})">
+            alt="">
           <div v-if="showArticleDate" class="author-date">
             <date-format
               :value="displayDate"


### PR DESCRIPTION
Before this change, when creating an article with image and access to the stream page, the image of the article has alt=[article name].
To fix this problem, we will change the alt to empty. After this change, the alt is displayed correctly.

Resolves https://github.com/Meeds-io/meeds/issues/3337