### PR TITLE
fix: Have an accessible name for published articles in stream - MEED-9171 - Meeds-io/meeds#3345

### DIFF
--- a/content-service/src/main/resources/locale/portlet/news/News_en.properties
+++ b/content-service/src/main/resources/locale/portlet/news/News_en.properties
@@ -92,6 +92,7 @@ news.details.editPublishing.title=Edit posting / publishing
 news.activity.notAuthorizedUser=To react to this article, you must be a member of the space {0}.
 news.activity.notAuthorizedUserForSpaceHidden=To react to this article, you must be a space member.
 news.activity.clickToShowDetail=Click here for more details
+news.activity.clickToAccessArticle=Access to article: {0}
 
 news.notification.description={0} has posted  in the {2} space an article
 news.notification.description.mention.in.news=You have been mentioned in the article:

--- a/content-webapp/src/main/webapp/vue-app/news-extensions/activity-stream-extensions/extensions.js
+++ b/content-webapp/src/main/webapp/vue-app/news-extensions/activity-stream-extensions/extensions.js
@@ -88,7 +88,6 @@ const newsActivityTypeExtensionOptions = {
     }
     return '';
   },
-  getTooltip: (activity, isActivityDetail) => !isActivityDetail && activity && 'news.activity.clickToShowDetail',
   getActivityViews: (activity) => {
     if (activity?.news?.viewsCount > 0) {
       const news = activity?.news;

--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsSliderView.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsSliderView.vue
@@ -39,8 +39,7 @@
               ? item.illustrationURL.concat('&size=1420x222')
               : '/content/images/news.png'"
             alt=""
-            class="articleImage object-fit-cover width-full full-height"
-          />
+            class="articleImage object-fit-cover width-full full-height">
           <v-container class="slide-text-container d-flex text-center">
             <div class="flex flex-column carouselNewsInfo">
               <div


### PR DESCRIPTION
Before this change, when create an article and access to the stream page, a class a containing a title=Click here for more details. To fix this problem, delete this title. After this change, no tooltip is displayed in the activity in the component which opens the activity detail.