### PR TITLE
fix: Implement UP to cleanup duplicated News ES indexes - MEED-8747 - Meeds-io/meeds#3218

### DIFF
--- a/content-service/src/main/java/io/meeds/content/news/service/NewsService.java
+++ b/content-service/src/main/java/io/meeds/content/news/service/NewsService.java
@@ -68,7 +68,6 @@ import org.exoplatform.social.core.activity.model.ExoSocialActivityImpl;
 import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
 import org.exoplatform.social.core.manager.ActivityManager;
 import org.exoplatform.social.core.manager.IdentityManager;
-import org.exoplatform.social.core.service.LinkProvider;
 import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceService;
 import org.exoplatform.social.core.utils.MentionUtils;
@@ -113,7 +112,6 @@ import io.meeds.content.news.utils.NewsUtils.NewsObjectType;
 import io.meeds.notes.model.NotePageProperties;
 import io.meeds.social.html.model.HtmlTransformerContext;
 import io.meeds.social.html.utils.HtmlUtils;
-
 import lombok.SneakyThrows;
 
 @Service
@@ -223,7 +221,7 @@ public class NewsService {
 
   @Autowired
   private NewsSearchConnector      newsSearchConnector;
-
+  
   @Autowired
   private UserACL                  userAcl;
 
@@ -606,9 +604,19 @@ public class NewsService {
     }
     return news;
   }
+  
+  /**
+   * Retrieves a news identified by its technical identifier without identity and lang
+   *
+   * @param newsId {@link News} identifier
+   * @return {@link News} if found else null
+   */
+  public News buildArticle(String newsId) throws Exception {
+    return buildArticle(newsId, null, null, false);
+  }
 
   /**
-   * Retrives a news identified by its technical identifier
+   * Retrieves a news identified by its technical identifier
    * 
    * @param newsId {@link News} identifier
    * @return {@link News} if found else null
@@ -1731,7 +1739,7 @@ public class NewsService {
                           .filter(Objects::nonNull)
                           .toList();
   }
-
+  
   private List<News> getPostedArticles(NewsFilter filter, Identity currentIdentity) throws Exception {
     MetadataFilter metadataFilter = new MetadataFilter();
     metadataFilter.setMetadataName(NEWS_METADATA_NAME);
@@ -2192,10 +2200,6 @@ public class NewsService {
       return news;
     }
     return null;
-  }
-
-  private News buildArticle(String newsId) throws Exception {
-    return buildArticle(newsId, null, null, false);
   }
 
   private News buildArticle(String newsId, Identity currentIdentity, String lang, boolean fetchOriginal) throws Exception {

--- a/content-service/src/main/java/io/meeds/content/news/upgrade/CleanDuplicatedEsIndexesUpgrade.java
+++ b/content-service/src/main/java/io/meeds/content/news/upgrade/CleanDuplicatedEsIndexesUpgrade.java
@@ -1,0 +1,214 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.content.news.upgrade;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.collections4.ListUtils;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
+
+import org.exoplatform.commons.api.settings.SettingService;
+import org.exoplatform.commons.api.settings.SettingValue;
+import org.exoplatform.commons.api.settings.data.Context;
+import org.exoplatform.commons.api.settings.data.Scope;
+import org.exoplatform.commons.search.es.client.ElasticSearchingClient;
+import org.exoplatform.commons.search.index.IndexingService;
+import org.exoplatform.commons.upgrade.UpgradePluginExecutionContext;
+import org.exoplatform.commons.upgrade.UpgradeProductPlugin;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+import org.exoplatform.wiki.jpa.search.WikiPageIndexingServiceConnector;
+
+import io.meeds.content.news.model.News;
+import io.meeds.content.news.service.NewsService;
+
+public class CleanDuplicatedEsIndexesUpgrade extends UpgradeProductPlugin {
+
+  private static final Log       LOG                                 =
+                                     ExoLogger.getLogger(CleanDuplicatedEsIndexesUpgrade.class.getName());
+
+  private ElasticSearchingClient elasticSearchingClient;
+
+  private IndexingService        indexingService;
+
+  private NewsService            newsService;
+
+  private SettingService         settingService;
+
+  private int                    cleanedDuplicatedNewsEsIndexesCount = 0;
+
+  private boolean                cleanupFailed                       = false;
+
+  private static final String    PLUGIN_NAME                         = "CleanDuplicatedEsIndexesUpgrade";
+
+  private static final String    PLUGIN_EXECUTED_KEY                 = "cleanDuplicatedEsIndexesUpgradeExecuted";
+
+  public CleanDuplicatedEsIndexesUpgrade(InitParams initParams,
+                                         NewsService newsService,
+                                         ElasticSearchingClient elasticSearchingClient,
+                                         IndexingService indexingService,
+                                         SettingService settingService) {
+    super(initParams);
+    this.newsService = newsService;
+    this.elasticSearchingClient = elasticSearchingClient;
+    this.indexingService = indexingService;
+    this.settingService = settingService;
+  }
+
+  @Override
+  public void processUpgrade(String oldVersion, String newVersion) {
+    long startupTime = System.currentTimeMillis();
+    LOG.info("Start cleanup of duplicated News ES indexes");
+    int notCleanedDuplicatedNewsEsIndexesCount = 0;
+    int processedDuplicatedNewsEsIndexesCount = 0;
+    int totalDuplicatedNewsEsIndexesCount = 0;
+    try {
+      String matchAllQuery = "{\n" + "  \"query\": {\n" + "    \"match_all\": {}\n" + "  },\n" + "  \"size\": 10000\n" + "}";
+
+      String notesMatchAllQueryResponse = this.elasticSearchingClient.sendRequest(matchAllQuery, "notes_v1");
+      List<String> duplicatedNewsEsIndexes = getDuplicatedNewsEsIndexes(notesMatchAllQueryResponse);
+      if (duplicatedNewsEsIndexes != null) {
+        totalDuplicatedNewsEsIndexesCount = duplicatedNewsEsIndexes.size();
+        LOG.info("Total number of duplicated News ES indexes to be cleaned: {}", totalDuplicatedNewsEsIndexesCount);
+        if (duplicatedNewsEsIndexes != null) {
+          for (List<String> duplicatedNewsEsIndexesChunk : ListUtils.partition(duplicatedNewsEsIndexes, 10)) {
+            int processedDuplicatedNewsEsIndexesCountByTransaction = duplicatedNewsEsIndexesChunk.size();
+            int notCleanedDuplicatedNewsEsIndexesCountByTransaction = manageDuplicatedNewsEsIndexes(duplicatedNewsEsIndexesChunk);
+            processedDuplicatedNewsEsIndexesCount += processedDuplicatedNewsEsIndexesCountByTransaction;
+            cleanedDuplicatedNewsEsIndexesCount += processedDuplicatedNewsEsIndexesCountByTransaction
+                - notCleanedDuplicatedNewsEsIndexesCountByTransaction;
+            notCleanedDuplicatedNewsEsIndexesCount += notCleanedDuplicatedNewsEsIndexesCountByTransaction;
+            LOG.info("Duplicated News ES indexes cleanup progress: processed={}/{} succeeded={} error={}",
+                     processedDuplicatedNewsEsIndexesCount,
+                     totalDuplicatedNewsEsIndexesCount,
+                     cleanedDuplicatedNewsEsIndexesCount,
+                     notCleanedDuplicatedNewsEsIndexesCount);
+          }
+        }
+      }
+    } catch (Exception e) {
+      this.cleanupFailed = true;
+      LOG.error("An error occurred when cleanup duplicated News ES indexes:", e);
+    }
+    if (!this.cleanupFailed && totalDuplicatedNewsEsIndexesCount == cleanedDuplicatedNewsEsIndexesCount) {
+      LOG.info("End duplicated News ES indexes successful cleanup: total={} succeeded={} error={}. It tooks {} ms.",
+               totalDuplicatedNewsEsIndexesCount,
+               cleanedDuplicatedNewsEsIndexesCount,
+               notCleanedDuplicatedNewsEsIndexesCount,
+               (System.currentTimeMillis() - startupTime));
+    } else {
+      LOG.warn("End duplicated News ES indexes cleanup with some errors: total={} succeeded={} error={}. It tooks {} ms."
+          + " The not cleaned news articles will be processed again next startup.",
+               totalDuplicatedNewsEsIndexesCount,
+               cleanedDuplicatedNewsEsIndexesCount,
+               notCleanedDuplicatedNewsEsIndexesCount,
+               (System.currentTimeMillis() - startupTime));
+      this.cleanupFailed = true;
+      throw new IllegalStateException("Some duplicated News ES indexes wasn't executed successfully. It will be re-attempted next startup");
+    }
+  }
+
+  @Override
+  public void afterUpgrade() {
+    if (!cleanupFailed) {
+      settingService.set(Context.GLOBAL.id(PLUGIN_NAME),
+                         Scope.APPLICATION.id(PLUGIN_NAME),
+                         PLUGIN_EXECUTED_KEY,
+                         SettingValue.create(true));
+    }
+  }
+
+  @Override
+  public boolean shouldProceedToUpgrade(String newVersion,
+                                        String previousGroupVersion,
+                                        UpgradePluginExecutionContext upgradePluginExecutionContext) {
+    SettingValue<?> settingValue = settingService.get(Context.GLOBAL.id(PLUGIN_NAME),
+                                                      Scope.APPLICATION.id(PLUGIN_NAME),
+                                                      PLUGIN_EXECUTED_KEY);
+    boolean shouldUpgrade = super.shouldProceedToUpgrade(newVersion, previousGroupVersion, upgradePluginExecutionContext);
+    if (!shouldUpgrade && settingValue == null) {
+      settingService.set(Context.GLOBAL.id(PLUGIN_NAME),
+                         Scope.APPLICATION.id(PLUGIN_NAME),
+                         PLUGIN_EXECUTED_KEY,
+                         SettingValue.create(true));
+    }
+    return shouldUpgrade;
+  }
+
+  public int manageDuplicatedNewsEsIndexes(List<String> duplicatedNewsEsIndexes) {
+    int notCleanedDuplicatedNewsEsIndexesCountByTransaction = 0;
+    for (String duplicatedNewsEsIndex : duplicatedNewsEsIndexes) {
+      try {
+        LOG.info("Cleaning duplicated News ES index with id '{}'", duplicatedNewsEsIndex);
+        indexingService.unindex(WikiPageIndexingServiceConnector.TYPE, duplicatedNewsEsIndex);
+        LOG.info("Success cleaning News ES index with id '{}'", duplicatedNewsEsIndex);
+      } catch (Exception e) {
+        notCleanedDuplicatedNewsEsIndexesCountByTransaction++;
+        LOG.warn("Error cleaning duplicated news ES index with id '{}'. Continue to migrate other items",
+                 duplicatedNewsEsIndex,
+                 e);
+      }
+    }
+    return notCleanedDuplicatedNewsEsIndexesCountByTransaction;
+  }
+
+  public int getCleanedDuplicatedNewsEsIndexesCount() {
+    return cleanedDuplicatedNewsEsIndexesCount;
+  }
+
+  private List<String> getDuplicatedNewsEsIndexes(String queryResponse) {
+
+    List<String> duplicatedNewsEsIndexes = new ArrayList<>();
+    JSONParser parser = new JSONParser();
+    Map queryJsonResponse;
+    try {
+      queryJsonResponse = (Map) parser.parse(queryResponse);
+    } catch (ParseException e) {
+      return null;
+    }
+
+    JSONObject queryJsonResult = (JSONObject) queryJsonResponse.get("hits");
+    JSONArray queryJsonHits = (JSONArray) queryJsonResult.get("hits");
+
+    for (Object queryJsonHit : queryJsonHits) {
+      String noteId = ((JSONObject) queryJsonHit).get("_id").toString();
+      String articleId = noteId;
+      if (noteId.contains("-")) {
+        articleId = noteId.substring(0, noteId.indexOf("-"));
+      }
+      News article = null;
+      try {
+        article = newsService.buildArticle(articleId);
+        if (article != null && !article.isReferred() && !article.isFromExternalPage()) {
+          duplicatedNewsEsIndexes.add(noteId);
+        }
+      } catch (Exception e) {
+        LOG.warn("Error retrieving article id '{}'", noteId);
+      }
+    }
+    return duplicatedNewsEsIndexes;
+  }
+}

--- a/content-service/src/test/java/io/meeds/content/news/upgrade/CleanDuplicatedEsIndexesUpgradeTest.java
+++ b/content-service/src/test/java/io/meeds/content/news/upgrade/CleanDuplicatedEsIndexesUpgradeTest.java
@@ -1,0 +1,116 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.content.news.upgrade;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import org.exoplatform.commons.api.settings.SettingService;
+import org.exoplatform.commons.search.es.client.ElasticSearchingClient;
+import org.exoplatform.commons.search.index.IndexingService;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.container.xml.ValueParam;
+
+import io.meeds.content.news.model.News;
+import io.meeds.content.news.service.NewsService;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CleanDuplicatedEsIndexesUpgradeTest {
+
+  private CleanDuplicatedEsIndexesUpgrade cleanDuplicatedEsIndexesUpgrade;
+
+  @Mock
+  private ElasticSearchingClient          elasticSearchingClient;
+
+  @Mock
+  private IndexingService                 indexingService;
+
+  @Mock
+  private NewsService                     newsService;
+
+  @Mock
+  private SettingService                  settingService;
+
+  InitParams                              initParams = new InitParams();
+
+  @Before
+  public void setUp() {
+    ValueParam productGroupIdValueParam = new ValueParam();
+    productGroupIdValueParam.setName("product.group.id");
+    productGroupIdValueParam.setValue("org.exoplatform.platform");
+    initParams.addParameter(productGroupIdValueParam);
+    this.cleanDuplicatedEsIndexesUpgrade = new CleanDuplicatedEsIndexesUpgrade(initParams,
+                                                                               newsService,
+                                                                               elasticSearchingClient,
+                                                                               indexingService,
+                                                                               settingService);
+  }
+
+  @Test
+  public void testProcessUpgrade() throws Exception {
+
+    String queryResponse = "{\n" + "  \"took\": 5,\n" + "  \"timed_out\": false,\n" + "  \"_shards\": {\n" + "    \"total\": 1,\n"
+        + "    \"successful\": 1,\n" + "    \"skipped\": 0,\n" + "    \"failed\": 0\n" + "  },\n" + "  \"hits\": {\n"
+        + "    \"total\": {\n" + "      \"value\": 5,\n" + "      \"relation\": \"eq\"\n" + "    },\n"
+        + "    \"max_score\": 1.0,\n" + "    \"hits\": [\n" + "      {\n" + "        \"_index\": \"notes_v1\",\n"
+        + "        \"_type\": \"_doc\",\n" + "        \"_id\": \"1\",\n" + "        \"_score\": 1.0,\n"
+        + "        \"_source\": {\n" + "          \"title\": \"Title 1\"\n" + "        }\n" + "      },\n" + "      {\n"
+        + "        \"_index\": \"notes_v1\",\n" + "        \"_type\": \"_doc\",\n" + "        \"_id\": \"1-en\",\n"
+        + "        \"_score\": 1.0,\n" + "        \"_source\": {\n" + "          \"title\": \"Title 1 EN\"\n" + "        }\n"
+        + "      },\n" + "      {\n" + "        \"_index\": \"notes_v1\",\n" + "        \"_type\": \"_doc\",\n"
+        + "        \"_id\": \"4\",\n" + "        \"_score\": 1.0,\n" + "        \"_source\": {\n"
+        + "          \"title\": \"Title 4\"\n" + "        }\n" + "      }\n" + "      {\n" + "        \"_index\": \"notes_v1\",\n"
+        + "        \"_type\": \"_doc\",\n" + "        \"_id\": \"4-fr\",\n" + "        \"_score\": 1.0,\n"
+        + "        \"_source\": {\n" + "          \"title\": \"Title 4 fr\"\n" + "        }\n" + "      }\n" + "      {\n"
+        + "        \"_index\": \"notes_v1\",\n" + "        \"_type\": \"_doc\",\n" + "        \"_id\": \"5\",\n"
+        + "        \"_score\": 1.0,\n" + "        \"_source\": {\n" + "          \"title\": \"Title 5\"\n" + "        }\n"
+        + "      }\n" + "    ]\n" + "  }\n" + "}";
+
+    when(elasticSearchingClient.sendRequest(anyString(), anyString())).thenReturn(queryResponse);
+    News article1 = mock(News.class);
+    News article2 = mock(News.class);
+    when(newsService.buildArticle(anyString())).thenReturn(article1)
+                                               .thenReturn(article1)
+                                               .thenReturn(article2)
+                                               .thenReturn(article2)
+                                               .thenReturn(null);
+    when(article1.isReferred()).thenReturn(true);
+    when(article2.isReferred()).thenReturn(false);
+    when(article2.isFromExternalPage()).thenReturn(false);
+
+    cleanDuplicatedEsIndexesUpgrade.processUpgrade("oldVersion", "newVersion");
+
+    // Verify the result
+    assertEquals(2, cleanDuplicatedEsIndexesUpgrade.getCleanedDuplicatedNewsEsIndexesCount());
+
+    verify(indexingService, times(2)).unindex(anyString(), anyString());
+
+  }
+}

--- a/content-webapp/src/main/webapp/WEB-INF/conf/news/news-configuration.xml
+++ b/content-webapp/src/main/webapp/WEB-INF/conf/news/news-configuration.xml
@@ -3,7 +3,7 @@
 
 	This file is part of the Meeds project (https://meeds.io/).
 
-  Copyright (C) 2020 - 2024 Meeds Association contact@meeds.io
+  Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
 	This program is free software; you can redistribute it and/or
 	modify it under the terms of the GNU Lesser General Public
 	License as published by the Free Software Foundation; either
@@ -56,6 +56,43 @@
           <property name="name" value="news"/>
           <property name="description" value="news files storage"/>
         </properties-param>
+      </init-params>
+    </component-plugin>
+  </external-component-plugins>
+  
+  <external-component-plugins>
+    <target-component>org.exoplatform.commons.upgrade.UpgradeProductService</target-component>    
+    <component-plugin profiles="content">
+      <name>CleanDuplicatedEsIndexesUpgrade</name>
+      <set-method>addUpgradePlugin</set-method>
+      <type>io.meeds.content.news.upgrade.CleanDuplicatedEsIndexesUpgrade</type>
+      <description>Cleanup duplicated News Es Indexes</description>
+      <init-params>
+        <value-param>
+          <name>product.group.id</name>
+          <description>The groupId of the product</description>
+          <value>org.exoplatform.platform</value>
+        </value-param>
+        <value-param>
+          <name>plugin.execution.order</name>
+          <description>The plugin execution order</description>
+          <value>1</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.execute.once</name>
+          <description>Execute this upgrade plugin only once</description>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.async.execution</name>
+          <description>The plugin will be executed in an asynchronous mode</description>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.target.version</name>
+          <description>Target version of the plugin</description>
+          <value>7.1.0</value>
+        </value-param>
       </init-params>
     </component-plugin>
   </external-component-plugins>


### PR DESCRIPTION

Prior to this change, after fixing the double indexing of an article as a note and news at the same time, some articles still double indexed since they are created before the fix.
To fix that cases in a migration context between for example the version 7.0.0-M52 not containing the fix and the last 7.1.0 version, we will implement an UP which will retrieve all notes indexes, unindex the note index id if it matches with the id of a not referred newsarticle/news article translation and not published note/note translation.

Resolves https://github.com/Meeds-io/meeds/issues/3218