### PR TITLE
fix: Set a suitable alt to images of published article - MEED-9198 - Meeds-io/meeds#3363

### DIFF
--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsCardsViewItem.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsCardsViewItem.vue
@@ -27,7 +27,7 @@
       <div class="imgContainer">
         <img
           :src="articleImage"
-          alt=""
+          :alt="featuredImageAltText"
           class="article-illustration-img">
       </div>
     </a>
@@ -150,7 +150,7 @@ export default {
       return this.selectedOption && this.selectedOption.showArticleSpace;
     },
     featuredImageAltText() {
-      return this.item?.properties?.featuredImage?.altText || this.$t('news.latest.alt.articleImage');
+      return this.item?.properties?.featuredImage?.altText || '';
     },
     articleImage() {
       return this.showArticleImage && this.item

--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsLatestViewItem.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsLatestViewItem.vue
@@ -27,7 +27,7 @@
     <div class="articleImage" v-if="showImage">
       <img 
         :src="articleImg"
-        alt=""
+        :alt="featuredImageAltText"
         class="card-border-radius">
     </div>
     <div class="articleInfos">
@@ -115,7 +115,7 @@ export default {
       return  this.showArticleImage || (!this.showArticleImage && !this.index );
     },
     featuredImageAltText() {
-      return this.item?.properties?.featuredImage?.altText || this.$t('news.latest.alt.articleImage');
+      return this.item?.properties?.featuredImage?.altText || '';
     },
     img() {
       return this.illustrationURL() || '/content/images/news.png';

--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsListTemplateViewItem.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsListTemplateViewItem.vue
@@ -26,7 +26,7 @@
     <div v-if="showArticleImage" class="article-item-image">
       <img
         :src="articleImage"
-        alt=""
+        :alt="featuredImageAltText"
         class="card-border-radius">
     </div>
     <div class="article-item-content">
@@ -126,7 +126,7 @@ export default {
       return this.selectedOption?.showArticleReactions;
     },
     featuredImageAltText() {
-      return this.item?.properties?.featuredImage?.altText || this.$t('news.latest.alt.articleImage');
+      return this.item?.properties?.featuredImage?.altText || '';
     },
     articleImage() {
       return this.item?.illustrationURL?.concat('&size=70x70').toString() || '/content/images/news.png';

--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsMosaicView.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsMosaicView.vue
@@ -39,7 +39,7 @@
             :href="articleUrl(item)">
             <img
               :src="showArticleImage && item.illustrationURL !== null ? illustrationURL(item,index) : '/content/images/news.png'"
-              alt=""
+              :alt="item?.properties?.featuredImage?.altText || ''"
               class="card-border-radius">
             <div class="titleArea">
               <div v-if="showArticleDate" class="articleDate">

--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsSliderView.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsSliderView.vue
@@ -38,7 +38,7 @@
             :src="showArticleImage && item.illustrationURL !== null
               ? item.illustrationURL.concat('&size=1420x222')
               : '/content/images/news.png'"
-            alt=""
+            :alt="item?.properties?.featuredImage?.altText || ''"
             class="articleImage object-fit-cover width-full full-height">
           <v-container class="slide-text-container d-flex text-center">
             <div class="flex flex-column carouselNewsInfo">

--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsStoriesViewItem.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsStoriesViewItem.vue
@@ -32,7 +32,7 @@
         <img
           class="article-img"
           :src="articleImage"
-          alt="">
+          :alt="featuredImageAltText">
         <div class="author-date-container">
           <img
             v-if="showArticleAuthor"
@@ -126,7 +126,10 @@ export default {
     },
     articleUrl() {
       return eXo.env.portal.userName !== '' ? this.item.url : `${eXo.env.portal.context}/${eXo.env.portal.portalName}/news-detail?newsId=${this.item.id}&type=article`;
-    }
+    },
+    featuredImageAltText() {
+      return this.item?.properties?.featuredImage?.altText || '';
+    },
   },
   created() {
     this.showSeeAll = this.$root.showSeeAll;


### PR DESCRIPTION
Before this change, when create an article with image and publish it in a News list, The image of the published article in the News list has alt empty. To fix this problem, add the alt text of news properties otherwise keep the alt empty. After this change, the alt text of the image is displayed correctly.

(cherry picked from commit fb9b3f02a1f28ad4b21f1f50e7b97f176c2f33f0)