### PR TITLE
fix: Fix lost of the content when editing a draft of a scheduled article - MEED-9289 - Meeds-io/meeds#3398

### DIFF
--- a/content-webapp/src/main/webapp/vue-app/news-activity-composer-app/components/ContentRichEditor.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-activity-composer-app/components/ContentRichEditor.vue
@@ -113,7 +113,6 @@ export default {
       editorBodyInputRef: 'articleContent',
       editorTitleInputRef: 'articleTitle',
       imagesURLs: new Map(),
-      canScheduleArticle: false,
       canPublishArticle: false,
       postKey: 1,
       editorIcon: 'fas fa-newspaper',
@@ -319,6 +318,7 @@ export default {
         updatedArticle.properties.draft = true;
       }
       updatedArticle.publicationState = 'draft';
+      this.articleType = this.scheduled && 'latest_draft' || this.articleType;
       return this.$newsServices.updateNews(updatedArticle, false, this.articleType).then((createdArticle) => {
         this.spaceUrl = createdArticle.spaceUrl;
         this.articleId = this.article.id = createdArticle.id;
@@ -677,9 +677,6 @@ export default {
         }
       }
       this.canPublishArticle = await this.$newsServices.canPublishNews(this.currentSpace.id);
-      if (this.article.id) {
-        this.canScheduleArticle = await this.$newsServices.canScheduleNews(this.currentSpace.id, this.article.id);
-      }
       this.loading = false;
     },
     async replaceSuggestedUsers(message, mentionedUsers) {

--- a/content-webapp/src/main/webapp/vue-app/news/components/NewsApp.vue
+++ b/content-webapp/src/main/webapp/vue-app/news/components/NewsApp.vue
@@ -308,10 +308,7 @@ export default {
       if (item.activityId) {
         draftUrl += `&activityId=${item.activityId}`;
       }
-      if (item.spaceUrl) {
-        draftUrl += `&spaceName=${item.spaceUrl.substring(item.spaceUrl.lastIndexOf('/') + 1)}`;
-      }
-      draftUrl += `&type=${(item.activityId || item.schedulePostDate) && 'latest_draft' || 'draft'}`;
+      draftUrl += `&type=${item.activityId && 'latest_draft' || 'draft'}`;
       if (item.lang) {
         draftUrl += `&lang=${item.lang}`;
       }


### PR DESCRIPTION
Prior to this change, when editing a scheduled article or its draft, we have an empty article in the news editor, this is due to a passed wrong newsId and type.
After this commit, we ensure to pass the right params newsId and type when editing a scheduled article or its draf.

Resolves https://github.com/Meeds-io/meeds/issues/3398