### PR TITLE
fix: Fix news list portlet headline template reactions text color of the cover article - MEED-9293 - Meeds-io/meeds#3282

### DIFF
--- a/content-webapp/src/main/webapp/skin/less/newsListView.less
+++ b/content-webapp/src/main/webapp/skin/less/newsListView.less
@@ -327,6 +327,9 @@
           color: @baseBackgroundDefault !important;
           text-shadow: 0 0 4px rgba(0, 0, 0, 0.86);
           margin: auto 15px 15px 15px;
+          .reactions {
+            color: white !important;  	   
+          }
         }
         .reactionIconStyle {
           color: @baseBackgroundDefault;


### PR DESCRIPTION
Prior to this change, the text color of the reactions displyed for cover article displayed in news list portlet headline template is gray which is not well visible. After this commit, to fix that for more visibility, we will change the color to white.

Resolves Meeds-io/meeds#328