### PR TITLE
fix: Add an icon for external links in the links portlet- MEED-9234 - Meeds-io/meeds#3374

### DIFF
--- a/content-webapp/src/main/webapp/vue-app/links/components/view/LinksCard.vue
+++ b/content-webapp/src/main/webapp/vue-app/links/components/view/LinksCard.vue
@@ -58,6 +58,12 @@
         :class="!showIcon && 'pb-3 my-auto'"
         class="pt-3 px-1 full-width text-truncate-2 text-body">
         {{ showName && name || '' }}
+        <v-icon
+          v-if="!link.sameTab"
+          size="16"
+          class="mb-1 text-color">
+          fa-external-link-alt
+        </v-icon>
       </div>
     </v-card>
   </component>

--- a/content-webapp/src/main/webapp/vue-app/links/components/view/LinksCard.vue
+++ b/content-webapp/src/main/webapp/vue-app/links/components/view/LinksCard.vue
@@ -60,8 +60,8 @@
         {{ showName && name || '' }}
         <v-icon
           v-if="!link.sameTab"
-          size="16"
-          class="mb-1 text-color">
+          size="12"
+          class="icon-default-color">
           fa-external-link-alt
         </v-icon>
       </div>

--- a/content-webapp/src/main/webapp/vue-app/links/components/view/LinksColumn.vue
+++ b/content-webapp/src/main/webapp/vue-app/links/components/view/LinksColumn.vue
@@ -39,10 +39,9 @@
         class="text-color text-start text-wrap"
         :class="showDescription && description && 'text-truncate' || 'text-truncate-2'">
         {{ name }}
-         <v-icon
+        <v-icon
           v-if="!link.sameTab"
-          size="16"
-          class="mb-1 text-color">
+          size="12">
           fa-external-link-alt
         </v-icon>
       </v-list-item-title>

--- a/content-webapp/src/main/webapp/vue-app/links/components/view/LinksColumn.vue
+++ b/content-webapp/src/main/webapp/vue-app/links/components/view/LinksColumn.vue
@@ -39,6 +39,12 @@
         class="text-color text-start text-wrap"
         :class="showDescription && description && 'text-truncate' || 'text-truncate-2'">
         {{ name }}
+         <v-icon
+          v-if="!link.sameTab"
+          size="16"
+          class="mb-1 text-color">
+          fa-external-link-alt
+        </v-icon>
       </v-list-item-title>
       <v-list-item-subtitle
         v-if="showDescription && description"


### PR DESCRIPTION
This change will add external-link icon when a link, that opens in a new tab, has been added to the links portlet.

Resolves Meeds-io/meeds#3374