### PR TITLE
fix: Align external-link-alt icon to links label - MEED-9352 (#548)

### DIFF
--- a/content-webapp/src/main/webapp/vue-app/links/components/view/LinksColumn.vue
+++ b/content-webapp/src/main/webapp/vue-app/links/components/view/LinksColumn.vue
@@ -41,6 +41,7 @@
         {{ name }}
         <v-icon
           v-if="!link.sameTab"
+          class="mt-n1"
           size="12">
           fa-external-link-alt
         </v-icon>


### PR DESCRIPTION
This change is going to align the external-link-alt icon to links label