### PR TITLE
fix: null value retreived when searching news prevents from displaying results - MEED-9395 - meeds-io/meeds#3468

### DIFF
--- a/content-service/src/main/java/io/meeds/content/news/service/NewsService.java
+++ b/content-service/src/main/java/io/meeds/content/news/service/NewsService.java
@@ -804,7 +804,7 @@ public class NewsService {
         LOG.error("Error while building news article", e);
         return null;
       }
-    }).toList();
+    }).filter(Objects::nonNull).toList();
   }
 
   /**


### PR DESCRIPTION
before this change, when create 3 news which contains a common word then delete the metadata of one of these news with a query and go to news app in filter field type of common word, no articles found for this search. To fix this problem, filter the return list to remove news that is null. After this change, the retrieved news is displayed.