### PR TITLE
fix: Wrong sort of articles when searching by keyword - MEED-9531 - meeds-io/meeds#3543

### DIFF
--- a/content-service/src/main/resources/news-search-query.json
+++ b/content-service/src/main/resources/news-search-query.json
@@ -15,6 +15,13 @@
       @tags_query@
     }
   },
+  "sort": [
+    {
+      "lastUpdatedDate": {
+        "order": "desc"
+      }
+    }
+  ],
   "highlight" : {
     "number_of_fragments" : 2,
     "fragment_size" : 150,


### PR DESCRIPTION
before this change, when create news articles whose body contains test and go to news app then in search box type test, the news articles are displayed but randomly sorted. To fix this problem, add the sort and order to the query. After this change, the sort display should display first the last created/modified.
Resolves https://github.com/Meeds-io/meeds/issues/3543