### PR TITLE
fix: Missing margin between image and title of news when using arabic view - MEED-9539 - meeds-io/meeds#3489

### DIFF
--- a/content-webapp/src/main/webapp/skin/less/newsListView.less
+++ b/content-webapp/src/main/webapp/skin/less/newsListView.less
@@ -367,7 +367,7 @@
           justify-content: start;
           height: 96px;
           margin: 0;
-          padding: 0 0 0 12px;
+          padding-inline-start: 12px;
         }
         .articleTitle {
           line-height: 20px;
@@ -507,7 +507,7 @@
           justify-content: start;
           height: 96px;
           margin: 0;
-          padding: 0 0 0 12px;
+          padding-inline-start: 12px;
         }
         .articleTitle {
           line-height: 20px;
@@ -614,7 +614,7 @@
     min-width: 20px;
     border-radius: 5px;
     object-fit: cover;
-    margin-right: 6px;
+    margin-inline-end: 6px;
   }
   .articleTitle {
     display: block;


### PR DESCRIPTION
before this change, when create articles in spacex with featured image and publish them to news target of spacex then from personal setting set language to arabic and check display of news title and cover image, there is no margin between image and title. To fix this problem, change the margin-right in the spaceImage class to margin-inline-end and in the articleInfos class change the padding to padding-inline-start. After this change, there is a margin between news image and its title as it is the case in other languages.
Resolves https://github.com/Meeds-io/meeds/issues/3489