### PR TITLE
fix: Fix the displayed icon/image when editing a link - MEED-9494 - Meeds-io/meeds#3512 

### DIFF
--- a/content-webapp/src/main/webapp/vue-app/links/components/settings/LinkFormDrawer.vue
+++ b/content-webapp/src/main/webapp/vue-app/links/components/settings/LinkFormDrawer.vue
@@ -198,6 +198,11 @@ export default {
         }
       },
     },
+    'link.iconUploadId'() {
+      if (this.link.iconUploadId) {
+        this.link.icon = null;
+      }
+    },
     drawer() {
       if (this.drawer) {
         this.valid = false;
@@ -233,6 +238,9 @@ export default {
         link.iconSrc = null;
       }
       if (!link.icon) {
+        link.icon = null;
+      }
+      if (link.icon && link.iconUrl) {
         link.icon = null;
       }
       this.link = JSON.parse(JSON.stringify(link));


### PR DESCRIPTION
This change will empty the link icon when trying to upload image.