### PR TITLE
fix: Fix suggester in news editor - MEED-9526 - Meeds-io/meeds#3536

### DIFF
--- a/content-webapp/src/main/webapp/vue-app/news-activity-composer-app/components/ContentRichEditor.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-activity-composer-app/components/ContentRichEditor.vue
@@ -29,6 +29,8 @@
       :title-placeholder="contentFormTitlePlaceholder"
       :form-title="contentFormTitle"
       :suggester-space-url="spacePrettyName"
+      :suggester-space-pretty-name="spacePrettyName"
+      :suggester-space-id="spaceId"
       :app-name="appName"
       :languages="languages"
       :translations="translations"


### PR DESCRIPTION
This change will fix suggester in news editor after renaming a space.

(cherry picked from commit 1dab7c0a06a5ca8dce8bb7df2e2caa1e49dee1ed)