### PR TITLE
fix: RTL bad menu display of news details options - MEED-9549 - meeds-io/meeds#3559 

### DIFF
--- a/content-webapp/src/main/webapp/vue-app/news/components/ExoNewsDetailsActionMenuApp.vue
+++ b/content-webapp/src/main/webapp/vue-app/news/components/ExoNewsDetailsActionMenuApp.vue
@@ -21,10 +21,11 @@
 <template>
   <v-menu
     v-model="actionMenu"
+    :left="!$vuetify.rtl"
+    :right="$vuetify.rtl"
     attach
     eager
     bottom
-    left
     offset-y
     class="px-0 mx-2 pa-0 py-0 overflow-hidden newsMenu">
     <template #activator="{ on, attrs }">


### PR DESCRIPTION
Before this change, when access to any News detail and click on the three points button on the top left of the page, the menu appears on the left side of the button with bad display. To fix this problem, change the right and left menu layout depending on the context (LTR or RTL). After this change, on RTL mode, The menu option appears on the right side of the button.