### PR TITLE
fix: Adjust the marge between image and title of news in list news template - MEED-9556 - Meeds-io/meeds#3567

### DIFF
--- a/content-webapp/src/main/webapp/skin/less/newsListView.less
+++ b/content-webapp/src/main/webapp/skin/less/newsListView.less
@@ -1372,7 +1372,7 @@ p.caption-title:after {
     letter-spacing: 0.2px;
     line-height: 12px;
     overflow: hidden;
-    margin-left: 15px;
+    margin-inline-start: 15px;
     .text-body {
       line-height: normal;
       letter-spacing: normal;


### PR DESCRIPTION
This change will adjust the marge between image and title of news in list news template.