### PR TITLE
fix: Update shared news article activity after updating the original one - MEED-9682 - Meeds-io/meeds#3618 

### DIFF
--- a/content-service/src/main/java/io/meeds/content/news/service/NewsService.java
+++ b/content-service/src/main/java/io/meeds/content/news/service/NewsService.java
@@ -391,7 +391,7 @@ public class NewsService {
       indexingService.reindex(NewsIndexingServiceConnector.TYPE, String.valueOf(newsId));
     }
     if (!news.getPublicationState().isEmpty() && !DRAFT.equals(news.getPublicationState())) {
-      if (post != null && !CONTENT_AND_TITLE.name().equalsIgnoreCase(newsUpdateType)) {
+      if (post != null) {
         updateNewsActivity(news, post, originalNews.isActivityPosted());
       }
       NewsUtils.broadcastEvent(NewsUtils.UPDATE_NEWS, updater, news);


### PR DESCRIPTION
Prior to this change, when creating an article and sharing it in the activity feed, while updating the original, the shared one always remains unchanged. This fix will send the update activity event to resolve this issue.