### PR TITLE
fix: Fix displaying all targets allowed targets after target deletion - MEED-9697 - Meeds-io/meeds#3617

### DIFF
--- a/content-service/src/main/java/io/meeds/content/news/rest/NewsTargetingRest.java
+++ b/content-service/src/main/java/io/meeds/content/news/rest/NewsTargetingRest.java
@@ -18,12 +18,7 @@
  */
 package io.meeds.content.news.rest;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -40,13 +35,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 
-import org.exoplatform.container.ExoContainerContext;
-import org.exoplatform.container.PortalContainer;
-import org.exoplatform.container.component.RequestLifeCycle;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.services.security.ConversationState;
@@ -56,14 +47,10 @@ import org.exoplatform.social.metadata.model.Metadata;
 import io.meeds.content.news.rest.model.NewsTargetingEntity;
 import io.meeds.content.news.service.NewsTargetingService;
 import io.meeds.content.news.utils.NewsUtils;
-
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.annotation.PostConstruct;
-import jakarta.annotation.PreDestroy;
 
 @RestController
 @RequestMapping("targeting")
@@ -74,26 +61,6 @@ public class NewsTargetingRest {
 
   @Autowired
   private NewsTargetingService     newsTargetingService;
-
-  @Autowired
-  private PortalContainer          container;
-
-  private ScheduledExecutorService scheduledExecutor;
-
-  private Map<String, String>      newsTargetToDeleteQueue = new HashMap<>();
-
-
-  @PostConstruct
-  public void init() {
-    scheduledExecutor = Executors.newScheduledThreadPool(1);
-  }
-
-  @PreDestroy
-  public void destroy() {
-    if (scheduledExecutor != null) {
-      scheduledExecutor.shutdown();
-    }
-  }
 
   @GetMapping(produces = MediaType.APPLICATION_JSON)
   @Secured("users")
@@ -134,72 +101,17 @@ public class NewsTargetingRest {
       @ApiResponse(responseCode = "401", description = "User not authorized to delete the news target"),
       @ApiResponse(responseCode = "500", description = "Internal server error") })
   public Response deleteTarget(@PathVariable("targetName")
-                               String targetName,
-                               @Parameter(description = "Time to effectively delete news target")
-                               @RequestParam(name = "delay", required = false)
-                               long delay) {
+                               String targetName) {
     org.exoplatform.services.security.Identity currentIdentity = ConversationState.getCurrent().getIdentity();
     try {
       if (StringUtils.isBlank(targetName)) {
         return Response.status(Response.Status.BAD_REQUEST).entity("Target name ist mandatory").build();
       }
-      if (delay > 0) {
-        newsTargetToDeleteQueue.put(targetName, currentIdentity.getUserId());
-        scheduledExecutor.schedule(() -> {
-          if (newsTargetToDeleteQueue.containsKey(targetName)) {
-            ExoContainerContext.setCurrentContainer(container);
-            RequestLifeCycle.begin(container);
-            try {
-              newsTargetToDeleteQueue.remove(targetName);
-              newsTargetingService.deleteTargetByName(targetName, currentIdentity);
-            } catch (IllegalAccessException e) {
-              LOG.warn("User '{}' is not authorized to delete the news target with name " + targetName,
-                       currentIdentity.getUserId(),
-                       e);
-            } catch (Exception e) {
-              LOG.error("Error when deleting the news target with name " + targetName, e);
-            } finally {
-              RequestLifeCycle.end();
-            }
-          }
-        }, delay, TimeUnit.SECONDS);
-      } else {
-        newsTargetToDeleteQueue.remove(targetName);
-        newsTargetingService.deleteTargetByName(targetName, currentIdentity);
-      }
+      newsTargetingService.deleteTargetByName(targetName, currentIdentity);
       return Response.ok().build();
     } catch (Exception e) {
       LOG.error("Error when deleting the news target with name " + targetName, e);
       return Response.serverError().entity(e.getMessage()).build();
-    }
-  }
-
-  @PostMapping(path = "{targetName}/undoDelete")
-  @Secured("users")
-  @Operation(summary = "Undo deleting news target if not yet effectively deleted", method = "POST", description = "Undo deleting news target if not yet effectively deleted")
-  @ApiResponses(value = { @ApiResponse(responseCode = "400", description = "Invalid query input"),
-      @ApiResponse(responseCode = "403", description = "Forbidden operation") })
-  public Response undoDeleteTarget(@PathVariable("targetName")
-                                   String targetName) {
-    if (StringUtils.isBlank(targetName)) {
-      return Response.status(Response.Status.BAD_REQUEST).entity("Target name ist mandatory").build();
-    }
-    if (newsTargetToDeleteQueue.containsKey(targetName)) {
-      org.exoplatform.services.security.Identity currentIdentity = ConversationState.getCurrent().getIdentity();
-      String authenticatedUser = currentIdentity.getUserId();
-      String originalModifierUser = newsTargetToDeleteQueue.get(targetName);
-      if (!originalModifierUser.equals(authenticatedUser)) {
-        LOG.warn("User {} attempts to cancel deletion of a news target deleted by user {}",
-                 authenticatedUser,
-                 originalModifierUser);
-        return Response.status(Response.Status.FORBIDDEN).build();
-      }
-      newsTargetToDeleteQueue.remove(targetName);
-      return Response.noContent().build();
-    } else {
-      return Response.status(Response.Status.BAD_REQUEST)
-                     .entity("News target with name {} was already deleted or isn't planned to be deleted" + targetName)
-                     .build();
     }
   }
 

--- a/content-service/src/main/java/io/meeds/content/news/service/NewsTargetingService.java
+++ b/content-service/src/main/java/io/meeds/content/news/service/NewsTargetingService.java
@@ -84,7 +84,7 @@ public class NewsTargetingService {
    */
   public List<NewsTargetingEntity> getAllTargets() {
     List<Metadata> targets = metadataService.getMetadatas(METADATA_TYPE.getName(), 0);
-    return targets.stream().map(this::toEntity).toList();
+    return targets.stream().filter(targetMetadata -> targetMetadata.getProperties() != null).map(this::toEntity).toList();
   }
 
   /**
@@ -96,36 +96,31 @@ public class NewsTargetingService {
   public List<NewsTargetingEntity> getAllowedTargets(org.exoplatform.services.security.Identity userIdentity) {
     List<Metadata> allTargetsMetadatas = metadataService.getMetadatas(METADATA_TYPE.getName(), 0);
     return allTargetsMetadatas.stream()
-                              .filter(targetMetadata -> targetMetadata.getProperties().get(NewsUtils.TARGET_PERMISSIONS) != null
-                                                        && List.of(targetMetadata.getProperties()
-                                                                                 .get(NewsUtils.TARGET_PERMISSIONS)
-                                                                                 .split(","))
-                                                               .stream()
-                                                               .anyMatch(targetMetadataPermission -> {
-                                                                 if (targetMetadataPermission.contains(SPACE_TARGET_PERMISSION_PREFIX)) {
-                                                                   if (targetMetadataPermission.split(SPACE_TARGET_PERMISSION_PREFIX).length
-                                                                       > 1) {
-                                                                     Space targetPermissionSpace =
-                                                                                                 spaceService.getSpaceById(targetMetadataPermission.split(SPACE_TARGET_PERMISSION_PREFIX)[1]);
-                                                                     return targetPermissionSpace != null
-                                                                            && NewsUtils.canPublishNews(targetPermissionSpace.getId(),
-                                                                                                        userIdentity);
-                                                                   }
-                                                                   return false;
-                                                                 }
-                                                                 try {
-                                                                   Group targetPermissionGroup =
-                                                                                               organizationService.getGroupHandler()
-                                                                                                                  .findGroupById(targetMetadataPermission);
-                                                                   return targetPermissionGroup != null
-                                                                          && userIdentity.isMemberOf(targetMetadataPermission,
-                                                                                                     PUBLISHER_MEMBERSHIP_NAME);
-                                                                 } catch (Exception e) {
-                                                                   LOG.error("Could not find group from permission " +
-                                                                       targetMetadataPermission);
-                                                                   return false;
-                                                                 }
-                                                               }))
+                              .filter(targetMetadata -> targetMetadata.getProperties() != null
+                                  && targetMetadata.getProperties().get(NewsUtils.TARGET_PERMISSIONS) != null
+                                  && List.of(targetMetadata.getProperties().get(NewsUtils.TARGET_PERMISSIONS).split(","))
+                                         .stream()
+                                         .anyMatch(targetMetadataPermission -> {
+                                           if (targetMetadataPermission.contains(SPACE_TARGET_PERMISSION_PREFIX)) {
+                                             if (targetMetadataPermission.split(SPACE_TARGET_PERMISSION_PREFIX).length > 1) {
+                                               Space targetPermissionSpace =
+                                                                           spaceService.getSpaceById(targetMetadataPermission.split(SPACE_TARGET_PERMISSION_PREFIX)[1]);
+                                               return targetPermissionSpace != null
+                                                   && NewsUtils.canPublishNews(targetPermissionSpace.getId(), userIdentity);
+                                             }
+                                             return false;
+                                           }
+                                           try {
+                                             Group targetPermissionGroup =
+                                                                         organizationService.getGroupHandler()
+                                                                                            .findGroupById(targetMetadataPermission);
+                                             return targetPermissionGroup != null
+                                                 && userIdentity.isMemberOf(targetMetadataPermission, PUBLISHER_MEMBERSHIP_NAME);
+                                           } catch (Exception e) {
+                                             LOG.error("Could not find group from permission " + targetMetadataPermission);
+                                             return false;
+                                           }
+                                         }))
                               .map(this::toEntity)
                               .toList();
   }
@@ -406,9 +401,7 @@ public class NewsTargetingService {
   private NewsTargetingEntity toEntity(Metadata metadata) { // NOSONAR
     NewsTargetingEntity newsTargetingEntity = new NewsTargetingEntity();
     newsTargetingEntity.setName(metadata.getName());
-    if (metadata.getProperties() != null) {
-      newsTargetingEntity.setProperties(metadata.getProperties());
-    }
+    newsTargetingEntity.setProperties(metadata.getProperties());
     if (newsTargetingEntity.getProperties().get(NewsUtils.TARGET_PERMISSIONS) != null) {
       org.exoplatform.services.security.Identity currentIdentity = NewsUtils.getUserIdentity(RestUtils.getCurrentUser());
       boolean isSpacePublisher = false;

--- a/content-service/src/main/resources/locale/portlet/news/News_en.properties
+++ b/content-service/src/main/resources/locale/portlet/news/News_en.properties
@@ -244,8 +244,10 @@ newsTargets.settings.loadingResults=Search results
 newsTargets.settings.noResultsFound=No results
 news.newsTarget.deleteSuccess=Target deleted
 news.newsTarget.deleteCanceled=Target deletion canceled
-news.newsTarget.message.confirmDeleteNews=Do you want to remove this news target? It will no longer appear as a choice, but published articles will still be accessible from the News Center.
-news.newsTarget.title.confirmDeleteNews=Delete news target?
+news.newsTarget.message.confirmDeleteNews=You are about to delete the target. The article will no longer be published in the news list associated to this target.
+news.newsTarget.title.confirmDeleteNews=Target deletion
+news.newsTarget.confirmDeleteNews.button.delete=Delete
+news.newsTarget.confirmDeleteNews.cancel=Cancel
 
 news.publishTargets.management.addTarget=Add a target
 news.publishTargets.management.editTarget=Edit a target

--- a/content-service/src/main/resources/locale/portlet/news/News_fr.properties
+++ b/content-service/src/main/resources/locale/portlet/news/News_fr.properties
@@ -244,8 +244,10 @@ newsTargets.settings.loadingResults=Résultats de votre recherche
 newsTargets.settings.noResultsFound=Aucun résultat
 news.newsTarget.deleteSuccess=Cible supprimée
 news.newsTarget.deleteCanceled=La suppression de la cible a été annulée.
-news.newsTarget.message.confirmDeleteNews=Voulez-vous supprimer cette cible ? Elle n'apparaîtra plus dans les cibles possibles pour la diffusion des articles, mais ces derniers resteront publiés et accessibles dans le centre des articles. 
-news.newsTarget.title.confirmDeleteNews=Supprimer la cible ?
+news.newsTarget.message.confirmDeleteNews=Vous êtes sur le point de supprimer la cible. L'article ne sera plus publié dans la liste des actualités associées à cette cible.
+news.newsTarget.title.confirmDeleteNews=Suppression de la cible
+news.newsTarget.confirmDeleteNews.button.delete=Supprimer
+news.newsTarget.confirmDeleteNews.cancel=Annuler
 
 news.publishTargets.management.addTarget=Ajouter une cible
 news.publishTargets.management.editTarget=Modifier une cible

--- a/content-service/src/test/java/io/meeds/content/news/rest/NewsTargetingRestTest.java
+++ b/content-service/src/test/java/io/meeds/content/news/rest/NewsTargetingRestTest.java
@@ -29,9 +29,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.RuntimeDelegate;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -41,8 +39,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.server.ResponseStatusException;
 
-import org.exoplatform.container.PortalContainer;
-import org.exoplatform.services.rest.impl.RuntimeDelegateImpl;
 import org.exoplatform.services.security.ConversationState;
 import org.exoplatform.services.security.Identity;
 import org.exoplatform.social.core.manager.IdentityManager;
@@ -56,22 +52,13 @@ import io.meeds.content.news.utils.NewsUtils;
 public class NewsTargetingRestTest {
 
   @Mock
-  NewsTargetingService newsTargetingService;
+  NewsTargetingService      newsTargetingService;
 
   @Mock
-  PortalContainer      container;
-
-  @Mock
-  IdentityManager      identityManager;
+  IdentityManager           identityManager;
 
   @InjectMocks
   private NewsTargetingRest newsTargetingRestController;
-
-  @Before
-  public void setup() {
-    newsTargetingRestController.init();
-    RuntimeDelegate.setInstance(new RuntimeDelegateImpl());
-  }
 
   @Test
   public void shouldReturnOkWhenGetTargets() {
@@ -120,15 +107,15 @@ public class NewsTargetingRestTest {
     lenient().when(newsTargetingService.getAllTargets()).thenReturn(targets);
 
     // When
-    Response response = newsTargetingRestController.deleteTarget(targets.get(0).getName(), 0);
+    Response response = newsTargetingRestController.deleteTarget(targets.get(0).getName());
 
     // Then
     assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
 
-    when(newsTargetingRestController.deleteTarget(targets.get(0).getName(), 0)).thenThrow(RuntimeException.class);
+    when(newsTargetingRestController.deleteTarget(targets.get(0).getName())).thenThrow(RuntimeException.class);
 
     // When
-    response = newsTargetingRestController.deleteTarget(targets.get(0).getName(), 0);
+    response = newsTargetingRestController.deleteTarget(targets.get(0).getName());
 
     // Then
     assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
@@ -164,7 +151,6 @@ public class NewsTargetingRestTest {
     // When
     assertThrows(ResponseStatusException.class, () -> newsTargetingRestController.createNewsTarget(newsTargetingEntity));
 
-
   }
 
   @Test
@@ -193,8 +179,7 @@ public class NewsTargetingRestTest {
     // Then
     assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
 
-    when(newsTargetingRestController.updateNewsTarget(newsTargetingEntity,
-                                                       originalTargetName)).thenThrow(RuntimeException.class);
+    when(newsTargetingRestController.updateNewsTarget(newsTargetingEntity, originalTargetName)).thenThrow(RuntimeException.class);
 
     // When
     response = newsTargetingRestController.updateNewsTarget(newsTargetingEntity, originalTargetName);

--- a/content-webapp/src/main/webapp/vue-app/news-publish-targets-management/components/NewsPublishTargetsManagement.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-publish-targets-management/components/NewsPublishTargetsManagement.vue
@@ -116,8 +116,8 @@
         ref="deleteConfirmDialog"
         :message="$t('news.newsTarget.message.confirmDeleteNews')"
         :title="$t('news.newsTarget.title.confirmDeleteNews')"
-        :ok-label="$t('news.button.ok')"
-        :cancel-label="$t('news.button.cancel')"
+        :ok-label="$t('news.newsTarget.confirmDeleteNews.button.delete')"
+        :cancel-label="$t('news.newsTarget.confirmDeleteNews.cancel')"
         @ok="deleteNewsTarget(selectedTargetName)" />
       <news-publish-targets-management-drawer
         ref="newsPublishTargetsManagementDrawer"
@@ -178,26 +178,16 @@ export default {
       }
     },
     deleteNewsTarget(targetName) {
-      const deleteDelay = 6;
-      const redirectionTime = 8100;
-      this.$newsTargetingService.deleteTargetByName(targetName, deleteDelay)
+      this.$newsTargetingService.deleteTargetByName(targetName)
         .then(() => {
           this.$root.$emit('confirm-newsTarget-deletion', targetName);
-          const clickMessage = this.$t('news.details.undoDelete');
           const message = this.$t('news.newsTarget.deleteSuccess');
           document.dispatchEvent(new CustomEvent('alert-message', {detail: {
             alertType: 'success',
             alertMessage: message ,
-            alertLinkText: clickMessage ,
-            alertLinkCallback: () => this.undoDeleteNewsTarget(targetName),
           }}));
-        });
-      setTimeout(() => {
-        const deletedNewsTarget = localStorage.getItem('deletedNewsTarget');
-        if (deletedNewsTarget != null) {
           this.init();
-        }
-      }, redirectionTime);
+        });
     },
     deleteConfirmDialog(target) {
       this.selectedTargetName = target;
@@ -216,16 +206,6 @@ export default {
     },
     openAddTargetDrawer() {
       this.$refs.newsPublishTargetsManagementDrawer.open();
-    },
-    undoDeleteNewsTarget(targetName) {
-      return this.$newsTargetingService.undoDeleteTarget(targetName)
-        .then(() => {
-          const message =  this.$t('news.newsTarget.deleteCanceled');
-          document.dispatchEvent(new CustomEvent('alert-message', {detail: {
-            alertType: 'success',
-            alertMessage: message
-          }}));
-        });
     },
   }
 };

--- a/content-webapp/src/main/webapp/vue-app/services/newsTargetingService.js
+++ b/content-webapp/src/main/webapp/vue-app/services/newsTargetingService.js
@@ -40,29 +40,13 @@ export function getAllowedTargets() {
   });
 }
 
-export function deleteTargetByName(targetName, delay) {
-  if (delay > 0) {
-    localStorage.setItem('deletedNewsTarget', targetName);
-  }
-  return fetch(`${newsConstants.CONTENT_API}/targeting/${targetName}?delay=${delay || 0}`, {
+export function deleteTargetByName(targetName) {
+  return fetch(`${newsConstants.CONTENT_API}/targeting/${targetName}`, {
     credentials: 'include',
     method: 'DELETE'
   }).then((resp) => {
     if (resp && !resp.ok) {
       throw new Error('Error when deleting news target');
-    }
-  });
-}
-
-export function undoDeleteTarget(targetName) {
-  return fetch(`${newsConstants.CONTENT_API}/targeting/${targetName}/undoDelete`, {
-    method: 'POST',
-    credentials: 'include',
-  }).then((resp) => {
-    if (resp && resp.ok) {
-      localStorage.removeItem('deletedNewsTarget');
-    } else {
-      throw new Error('Error when undoing deleting news target');
     }
   });
 }


### PR DESCRIPTION

Prior to this change, when deleting a news target and before the expiration of the delay time we try to edit an article publication with affecting it the deleted target. The deletion is not well finished correctly with Metadata properties null, so the rest service to list all targets and allowed targets (/rest/targeting/allowed and getAllTargets) will through an NPE exception, hence no targets will be displayed in publish news targets list nor in news targets administration page. After this commit, we will avoid NullPointerException related to null Metadata properties of targets, so only the other not null targets having Metadata properties will be well retrieved and displayed and also perform news target deletion directly without delay time.

Resolves Meeds-io/meeds#3617