### PR TITLE
fix: news notifications must be set as relative link - MEED-8761 - meeds-io/meeds#2871.

### DIFF
--- a/content-webapp/src/main/webapp/vue-app/news-extensions/notification-extensions/components/PostNewsNotificationPlugin.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-extensions/notification-extensions/components/PostNewsNotificationPlugin.vue
@@ -44,7 +44,9 @@ export default {
   },
   computed: {
     url() {
-      return this.notification?.space?.isMember ? this.notification?.parameters?.ACTIVITY_LINK
+      let activityLink = this.notification?.parameters?.ACTIVITY_LINK;
+      activityLink = activityLink.substring(activityLink.indexOf(eXo.env.portal.context));
+      return this.notification?.space?.isMember ? activityLink
         : `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/news-detail?newsId=${this.notification?.parameters?.NEWS_ID}&type=article`;
     },
     eventTitle() {


### PR DESCRIPTION
before this change, when post and publish an article in a space and the members of this space receive on site notifs related to published/posted article then stop server and change server url in hosts and start server then click on received notifs, the url in notifs is the old one. To fix this problem, delete in the display of the notification the domain name in url send to . After this change, notifications for post/publish articles is relative url.