### PR TITLE
fix: Delete the aria-label on article title in the stream - MEED-9858

### DIFF
--- a/content-service/src/main/resources/locale/portlet/news/News_en.properties
+++ b/content-service/src/main/resources/locale/portlet/news/News_en.properties
@@ -92,7 +92,6 @@ news.details.editPublishing.title=Edit posting / publishing
 news.activity.notAuthorizedUser=To react to this article, you must be a member of the space {0}.
 news.activity.notAuthorizedUserForSpaceHidden=To react to this article, you must be a space member.
 news.activity.clickToShowDetail=Click here for more details
-news.activity.clickToAccessArticle=Access to article: {0}
 
 news.notification.description={0} has posted  in the {2} space an article
 news.notification.description.mention.in.news=You have been mentioned in the article:


### PR DESCRIPTION
This commit will delete unused label.