### PR TITLE
fix: Change tabulation behavior on articles displayed in cards template - MEED-9594 - Meeds-io/meeds#3589

### DIFF
--- a/content-webapp/src/main/webapp/vue-app/news/components/ExoNewsDetailsActionMenuApp.vue
+++ b/content-webapp/src/main/webapp/vue-app/news/components/ExoNewsDetailsActionMenuApp.vue
@@ -32,6 +32,7 @@
       <v-btn
         v-bind="attrs"
         :aria-label="$t('news.details.menu.open')"
+        :tabindex="isNotFocusable ? -1 : 0"
         class="pull-right"
         icon
         v-on="on"
@@ -104,7 +105,11 @@ export default {
     showReferButton: {
       type: Boolean,
       default: false
-    }
+    },
+    focusable: {
+      type: Boolean,
+      default: () => true,
+    },
   },
   data: () => ({
     actionMenu: null,
@@ -132,7 +137,10 @@ export default {
     },
     staged() {
       return this.news?.publicationState === 'staged';
-    }
+    },
+    isNotFocusable() {
+      return this.focusable === false || this.focusable === 'false';
+    },
   },
   methods: {
     copyLink() {

--- a/content-webapp/src/main/webapp/vue-app/news/components/NewsApp.vue
+++ b/content-webapp/src/main/webapp/vue-app/news/components/NewsApp.vue
@@ -93,6 +93,10 @@
           :news="news"
           :news-filter="newsFilter"
           class="newsItem"
+          tabindex="0"
+          role="article"
+          :aria-label="$t('news.illustration.link.title', {0: news.title})"
+          @keydown.native="openNewsOnEnter($event, news)"
           @update-news-list="updateNewsList"
           @delete-news="deleteNews"
           @open-delete-confirm-dialog="deleteConfirmDialog" />
@@ -271,7 +275,7 @@ export default {
   methods: {
     editLink(news) {
       const editUrl = this.getEditUrl(news);
-      window.open(editUrl, '_blank');
+      window.open(editUrl, '_target');
       this.$refs?.mobileActionMenu?.close();
     },
     deleteByConfirm() {
@@ -458,7 +462,12 @@ export default {
             alertMessage: message
           }}));
         });
-    }
+    },
+    openNewsOnEnter(event, news) {
+      if (event.key === 'Enter') {
+        window.open(news.url, '_self');
+      }
+    },
   },
 };
 </script>

--- a/content-webapp/src/main/webapp/vue-app/news/components/NewsAppItem.vue
+++ b/content-webapp/src/main/webapp/vue-app/news/components/NewsAppItem.vue
@@ -24,12 +24,16 @@
       :href="news.url"
       :style="{ 'background-image': 'url(' + illustrationUrl + ')' }"
       class="newsSmallIllustration"
+      tabindex="-1"
       :target="news.target"
       :aria-label="$t('news.illustration.link.title', {0: news.title})"></a>
     <div class="newsItemContent">
       <div class="newsItemContentHeader">
         <h3>
-          <a :href="news.url" :target="news.target">{{ news.title }} </a>
+          <a
+            :href="news.url"
+            :target="news.target"
+            tabindex="-1">{{ news.title }} </a>
         </h3>
         <news-spaces-shared-in
           v-if="news.activities && news.activities.split(';')[1]"
@@ -37,6 +41,7 @@
           :activities="news.activities" />
         <exo-news-details-action-menu-app
           v-if="!news.schedulePostDate"
+          focusable="false"
           :news="news"
           :show-edit-button="news.canEdit && !isDraftsFilter"
           :show-delete-button="news.canDelete"
@@ -51,6 +56,7 @@
           <exo-user-avatar
             :profile-id="newsAuthor"
             :size="25"
+            focusable="false"
             class="align-center width-full my-auto text-truncate flex-grow-0 flex"
             small-font-size
             popover />
@@ -63,6 +69,7 @@
           <exo-space-avatar
             v-if="!news.hiddenSpace"
             :space-id="spaceId"
+            focusable="false"
             class="width-full text-truncate"
             :size="25"
             extra-class="ps-1"
@@ -95,7 +102,10 @@
         </div>
       </div>
       <div class="newsItemContentDetails">
-        <a :href="news.url" :target="news.target">
+        <a
+          :href="news.url"
+          :target="news.target"
+          tabindex="-1">
           <p class="newsSummary" v-sanitized-html="news.newsText"></p>
         </a>
       </div>


### PR DESCRIPTION
Before this change, when navigating using the tab in the list of articles, we could focus on each detail of an article.
 After this commit, the tab navigation is changed to focus on the whole article, and tab press moves to the next article; also, pressing 'Enter' opens the selected article in the same tab.