### PR TITLE
fix: Change tabulation behavior on articles displayed in cards template - MEED-9594 - Meeds-io/meeds#3589

### DIFF
--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsCardsView.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsCardsView.vue
@@ -25,7 +25,11 @@
         v-for="(item, index) in news"
         :key="index"
         :item="item"
-        :selected-option="selectedOption" />
+        :selected-option="selectedOption"
+        tabindex="0"
+        role="article"
+        :aria-label="$t('news.illustration.link.title', {0: item.title})"
+        @keydown.native="openNewsOnEnter($event, item)" />
     </card-carousel>
   </div>
 </template>
@@ -51,5 +55,12 @@ export default {
       return this.newsList && this.newsList.filter(news => !!news);
     },
   },
+  methods: {
+    openNewsOnEnter(event, news) {
+      if (event.key === 'Enter') {
+        window.open(news.url, '_self');
+      }
+    },
+  }
 };
 </script>

--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsCardsViewItem.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsCardsViewItem.vue
@@ -19,10 +19,11 @@
 
 -->
 <template>
-  <div class="card card-border-radius">
+  <div class="card card-border-radius" tabindex="0">
     <a
       class="articleLink"
       target="_self"
+      tabindex="-1"
       :href="articleUrl">
       <div class="imgContainer">
         <img
@@ -35,6 +36,7 @@
       <div class="upper-row">
         <a
           v-if="!isHiddenSpace && showArticleSpace"
+          tabindex="-1"
           :id="`space-link-${item.activityId}`"
           :href="item.spaceUrl"
           class="space-link"
@@ -50,6 +52,7 @@
         </a>
         <a
           class="articleLink"
+          tabindex="-1"
           target="_self"
           :href="articleUrl">
           <div v-if="showArticleTitle" class="article-title text-body">{{ item.title }}</div>
@@ -71,6 +74,7 @@
       <div v-if="showArticleReactions" class="bottom-row border-top-color pa-2 width-full b-0 position-absolute white-background text-subtitle">
         <div class="d-flex text-truncate text-no-wrap">
           <a
+            tabindex="-1"
             class="width-fit-content"
             target="_self"
             :href="activityReactionsLink">
@@ -90,6 +94,7 @@
           </a>
           <a
             class="articleLink"
+            tabindex="-1"
             target="_self"
             :href="activityReactionsLink">
             <div class="views">

--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsCardsViewItem.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsCardsViewItem.vue
@@ -19,7 +19,7 @@
 
 -->
 <template>
-  <div class="card card-border-radius" tabindex="0">
+  <div class="card card-border-radius">
     <a
       class="articleLink"
       target="_self"
@@ -176,5 +176,6 @@ export default {
       return eXo.env.portal.userName !== '' ? this.item.url : `${eXo.env.portal.context}/${eXo.env.portal.portalName}/news-detail?newsId=${this.item.id}&type=article`;
     }
   }
+
 };
 </script>


### PR DESCRIPTION
Before this change, when navigating using the tab in the list of articles, we could focus on each detail of an article.
 After this commit, the tab navigation is changed to focus on the whole article, and tab press moves to the next article; also, pressing enter opens the selected article in the same tab.