### PR TITLE
fix: Do not display any aria-label or role on the div displaying the illustration of an article - MEED-9857 - meeds-io/meeds#3749

### DIFF
--- a/content-webapp/src/main/webapp/vue-app/news-details/components/ExoNewsDetailsBody.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-details/components/ExoNewsDetailsBody.vue
@@ -43,7 +43,7 @@
             <v-tooltip bottom>
               <template #activator="{ on, attrs }">
                 <span v-on="on" v-bind="attrs">
-                  <v-icon 
+                  <v-icon
                     size="20"
                     class="ms-3 icon-default-color">
                     fas fa-eye
@@ -216,7 +216,7 @@ export default {
       return this?.news.illustrationURL;
     },
     featuredImageAltText() {
-      return this.news?.properties?.featuredImage?.altText || this.newsTitle;
+      return this.news?.properties?.featuredImage?.altText || null;
     },
     newsTitle() {
       return this.news && this.newsTitleContent;


### PR DESCRIPTION
Before this fix, when a news have an illustration image, it is displayed throught a div which have aria-label attribute (containing the article title), and a role=img When the illustration have no alt text, it is a decorative image, and so, the aria-label and the role are not needed

Resolves meeds-io/meeds#3749