### PR TITLE
fix: Change tabulation behavior on articles displayed in cards template - MEED-9594 - Meeds-io/meeds#3589

### DIFF
--- a/content-webapp/src/main/webapp/skin/less/newsListView.less
+++ b/content-webapp/src/main/webapp/skin/less/newsListView.less
@@ -1125,49 +1125,48 @@ p.caption-title:after {
 }
 
 #cards-slider-large {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: normal;
-  -ms-flex-direction: column;
   flex-direction: column;
   position: relative;
   background: transparent;
   font-size: 14px;
   color: @textColor;
   line-height: 18px;
+
   .card {
+    display: block;
     position: relative;
     border-radius: 5px;
     background: white;
-    -webkit-transition: 0.3s;
-    -o-transition: 0.3s;
     transition: 0.3s;
     height: 300px;
     width: 235px;
     overflow: hidden;
     margin: 0 10px 0 0;
-    float: left;
-    -webkit-box-shadow: 0 1px 3px 0 rgba(35, 44, 48, 0.24);
     box-shadow: 0 1px 3px 0 rgba(35, 44, 48, 0.24);
-    -webkit-box-sizing: border-box;
     box-sizing: border-box;
     &:hover {
       cursor: pointer;
+
       .upper-row {
-        -webkit-transform: translateY(0);
-        -ms-transform: translateY(0);
+        transform: translateY(0);
+      }
+    }
+
+    &.keyboard-slide {
+      .upper-row {
         transform: translateY(0);
       }
     }
   }
+
   .articleLink {
     height: 100%;
     width: 100%;
     color: inherit;
     text-decoration: none;
   }
+
   .imgContainer {
     max-width: 235px;
     height: 140px;
@@ -1176,64 +1175,58 @@ p.caption-title:after {
     position: relative;
     border-radius: 5px 5px 0 0;
   }
+
   .article-illustration-img {
     max-width: 100%;
     position: absolute;
     height: 100%;
-    -o-object-fit: cover;
     object-fit: cover;
     width: 100%;
   }
+
   .text-area {
     position: relative;
     height: 160px;
     bottom: 4px;
     background: white;
   }
+
   .upper-row {
-    display: -webkit-box;
-    display: -ms-flexbox;
     display: flex;
-    -webkit-box-orient: vertical;
-    -webkit-box-direction: normal;
-    -ms-flex-flow: column;
     flex-flow: column;
     position: absolute;
+    left: 0;
     bottom: 49px;
     height: 241px;
     width: 100%;
+    box-sizing: border-box;
     padding: 10px;
-    -webkit-transform: translateY(calc(142px));
-    -ms-transform: translateY(calc(142px));
-    transform: translateY(calc(142px));
-    -webkit-transition: -webkit-transform 0.3s;
-    -o-transition: transform 0.3s;
-    transition: transform 0.3s, -webkit-transform 0.3s;
+
+    transform: translateY(142px);
+    transition: transform 0.3s;
     background: white;
   }
+
   .article-space {
-    display:-webkit-box;
-    display:-ms-flexbox;
-    display:flex;
+    display: flex;
     max-width: 216px;
     margin-bottom: 5px;
   }
+
   .space-link {
-    display: -webkit-box;
-    display: -ms-flexbox;
     display: flex;
     position: relative;
-    width: -webkit-fit-content;
-    width: -moz-fit-content;
     width: fit-content;
     padding-right: 5px;
     text-decoration: none;
+
     &:hover {
       .space-name {
-        color:  @primaryColor;
+        color: @primaryColor;
       }
     }
   }
+
   .space-icon {
     width: 21px;
     height: 21px;
@@ -1241,14 +1234,15 @@ p.caption-title:after {
     margin-top: -2px;
     margin-right: 5px;
   }
+
   .space-name {
     font-size: 12px;
     color: @greyColorLighten1;
     overflow: hidden;
     white-space: nowrap;
-    -o-text-overflow: ellipsis;
     text-overflow: ellipsis;
   }
+
   .article-title {
     letter-spacing: .1px;
     color: @textColor;
@@ -1257,51 +1251,54 @@ p.caption-title:after {
     -webkit-line-clamp: 3;
     overflow: hidden;
     margin-bottom: 5px;
+
     &:hover {
       color: @primaryColor;
     }
   }
+
   .author-name {
     overflow: hidden;
-    -o-text-overflow: ellipsis;
     text-overflow: ellipsis;
     white-space: nowrap;
   }
+
   .date {
     color: @greyColorLighten1;
   }
+
   .bottom-row {
     background: white;
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    box-sizing: border-box;
+    z-index: 10;
   }
+
   .article-counters {
     font-size: 12px;
     color: @greyColorLighten1;
+
     .counters-icons {
       color: @greyColorLighten1;
     }
   }
+
   .reactions {
-    display: -webkit-box;
-    display: -ms-flexbox;
     display: flex;
-    float: left;
     color: @greyColorLighten1;
   }
-  .likes-count {
-    float: right;
-    margin-top: -1px;
-    margin-right: 6px;
-  }
+
+  .likes-count,
   .comments-count {
-    float: right;
     margin-top: -1px;
     margin-right: 6px;
   }
+
   .views {
-    display: -webkit-box;
-    display: -ms-flexbox;
     display: flex;
-    float: right;
   }
 }
 


### PR DESCRIPTION
Before this change, when navigating using the tab in the list of articles we can focus on each details of an article.
 After this commit, the tab navigation is changed to focus on the whole article and tab press moved to the next article, also pressing enter opens the selected article in the same tab.