### PR TITLE
fix: Change tabulation behavior on articles displayed in cards template - MEED-9594 - Meeds-io/meeds#3589

### DIFF
--- a/content-webapp/src/main/webapp/skin/less/newsListView.less
+++ b/content-webapp/src/main/webapp/skin/less/newsListView.less
@@ -1125,49 +1125,48 @@ p.caption-title:after {
 }
 
 #cards-slider-large {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: normal;
-  -ms-flex-direction: column;
   flex-direction: column;
   position: relative;
   background: transparent;
   font-size: 14px;
   color: @textColor;
   line-height: 18px;
+
   .card {
+    display: block;
     position: relative;
     border-radius: 5px;
     background: white;
-    -webkit-transition: 0.3s;
-    -o-transition: 0.3s;
     transition: 0.3s;
     height: 300px;
     width: 235px;
     overflow: hidden;
     margin: 0 10px 0 0;
-    float: left;
-    -webkit-box-shadow: 0 1px 3px 0 rgba(35, 44, 48, 0.24);
     box-shadow: 0 1px 3px 0 rgba(35, 44, 48, 0.24);
-    -webkit-box-sizing: border-box;
     box-sizing: border-box;
     &:hover {
       cursor: pointer;
+
       .upper-row {
-        -webkit-transform: translateY(0);
-        -ms-transform: translateY(0);
+        transform: translateY(0);
+      }
+    }
+
+    &.keyboard-slide {
+      .upper-row {
         transform: translateY(0);
       }
     }
   }
+
   .articleLink {
     height: 100%;
     width: 100%;
     color: inherit;
     text-decoration: none;
   }
+
   .imgContainer {
     max-width: 235px;
     height: 140px;
@@ -1176,64 +1175,58 @@ p.caption-title:after {
     position: relative;
     border-radius: 5px 5px 0 0;
   }
+
   .article-illustration-img {
     max-width: 100%;
     position: absolute;
     height: 100%;
-    -o-object-fit: cover;
     object-fit: cover;
     width: 100%;
   }
+
   .text-area {
     position: relative;
     height: 160px;
     bottom: 4px;
     background: white;
   }
+
   .upper-row {
-    display: -webkit-box;
-    display: -ms-flexbox;
     display: flex;
-    -webkit-box-orient: vertical;
-    -webkit-box-direction: normal;
-    -ms-flex-flow: column;
     flex-flow: column;
     position: absolute;
+    left: 0;
     bottom: 49px;
     height: 241px;
     width: 100%;
+    box-sizing: border-box;
     padding: 10px;
-    -webkit-transform: translateY(calc(142px));
-    -ms-transform: translateY(calc(142px));
-    transform: translateY(calc(142px));
-    -webkit-transition: -webkit-transform 0.3s;
-    -o-transition: transform 0.3s;
-    transition: transform 0.3s, -webkit-transform 0.3s;
+
+    transform: translateY(142px);
+    transition: transform 0.3s;
     background: white;
   }
+
   .article-space {
-    display:-webkit-box;
-    display:-ms-flexbox;
-    display:flex;
+    display: flex;
     max-width: 216px;
     margin-bottom: 5px;
   }
+
   .space-link {
-    display: -webkit-box;
-    display: -ms-flexbox;
     display: flex;
     position: relative;
-    width: -webkit-fit-content;
-    width: -moz-fit-content;
     width: fit-content;
     padding-right: 5px;
     text-decoration: none;
+
     &:hover {
       .space-name {
-        color:  @primaryColor;
+        color: @primaryColor;
       }
     }
   }
+
   .space-icon {
     width: 21px;
     height: 21px;
@@ -1241,14 +1234,15 @@ p.caption-title:after {
     margin-top: -2px;
     margin-right: 5px;
   }
+
   .space-name {
     font-size: 12px;
     color: @greyColorLighten1;
     overflow: hidden;
     white-space: nowrap;
-    -o-text-overflow: ellipsis;
     text-overflow: ellipsis;
   }
+
   .article-title {
     letter-spacing: .1px;
     color: @textColor;
@@ -1257,51 +1251,54 @@ p.caption-title:after {
     -webkit-line-clamp: 3;
     overflow: hidden;
     margin-bottom: 5px;
+
     &:hover {
       color: @primaryColor;
     }
   }
+
   .author-name {
     overflow: hidden;
-    -o-text-overflow: ellipsis;
     text-overflow: ellipsis;
     white-space: nowrap;
   }
+
   .date {
     color: @greyColorLighten1;
   }
+
   .bottom-row {
     background: white;
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    box-sizing: border-box;
+    z-index: 10;
   }
+
   .article-counters {
     font-size: 12px;
     color: @greyColorLighten1;
+
     .counters-icons {
       color: @greyColorLighten1;
     }
   }
+
   .reactions {
-    display: -webkit-box;
-    display: -ms-flexbox;
     display: flex;
-    float: left;
     color: @greyColorLighten1;
   }
-  .likes-count {
-    float: right;
-    margin-top: -1px;
-    margin-right: 6px;
-  }
+
+  .likes-count,
   .comments-count {
-    float: right;
     margin-top: -1px;
     margin-right: 6px;
   }
+
   .views {
-    display: -webkit-box;
-    display: -ms-flexbox;
     display: flex;
-    float: right;
   }
 }
 

--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsCardsView.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsCardsView.vue
@@ -25,7 +25,10 @@
         v-for="(item, index) in news"
         :key="index"
         :item="item"
-        :selected-option="selectedOption" />
+        :selected-option="selectedOption"
+        tabindex="0"
+        role="article"
+        :aria-label="$t('news.illustration.link.title', {0: item.title})" />
     </card-carousel>
   </div>
 </template>
@@ -50,6 +53,6 @@ export default {
     news(){
       return this.newsList && this.newsList.filter(news => !!news);
     },
-  },
+  }
 };
 </script>

--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsCardsViewItem.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsCardsViewItem.vue
@@ -19,88 +19,105 @@
 
 -->
 <template>
-  <div class="card card-border-radius">
-    <a
-      class="articleLink"
-      target="_self"
-      :href="articleUrl">
-      <div class="imgContainer">
-        <img
-          :src="articleImage"
-          :alt="featuredImageAltText"
-          class="article-illustration-img">
-      </div>
-    </a>
+  <a
+    class="card card-border-radius"
+    :href="articleUrl"
+    target="_self"
+    @keydown="onCardKeydown"
+    @focus="onCardFocus"
+    @blur="onCardBlur"
+    :class="{ 'keyboard-slide': slideActive }"
+    ref="cardEl"
+    tabindex="0">
+    <div class="imgContainer">
+      <img
+        :src="articleImage"
+        :alt="featuredImageAltText"
+        class="article-illustration-img">
+    </div>
     <div class="text-area">
       <div class="upper-row">
-        <a
+        <div
           v-if="!isHiddenSpace && showArticleSpace"
           :id="`space-link-${item.activityId}`"
-          :href="item.spaceUrl"
           class="space-link"
-          target="_self"
-          :arial-label="$t('news.space.icon.title',{ 0:item.spaceDisplayName })">
+          :aria-label="$t('news.space.icon.title', { 0: item.spaceDisplayName })">
           <div class="article-space">
             <img
               class="space-icon"
               :src="item.spaceAvatarUrl"
               alt="">
-            <div class="space-name text-subtitle">{{ item.spaceDisplayName }}</div>
+            <div class="space-name text-subtitle">
+              {{ item.spaceDisplayName }}
+            </div>
           </div>
-        </a>
-        <a
-          class="articleLink"
-          target="_self"
-          :href="articleUrl">
-          <div v-if="showArticleTitle" class="article-title text-body">{{ item.title }}</div>
+        </div>
+        <div class="articleLink">
+          <div v-if="showArticleTitle" class="article-title text-body">
+            {{ item.title }}
+          </div>
           <div class="d-flex text-no-wrap text-truncate text-subtitle">
-            <div v-if="showArticleAuthor" class="author-name">{{ item.authorDisplayName }}</div>
-                
-            <span v-if="showArticleAuthor && showArticleDate">,&nbsp;</span>
+            <div v-if="showArticleAuthor" class="author-name">
+              {{ item.authorDisplayName }}
+            </div>
+            <span v-if="showArticleAuthor && showArticleDate">, </span>
             <div v-if="showArticleDate">
               <date-format
                 :value="displayDate"
                 :format="dateFormat" />
             </div>
-                
           </div>
-          <div v-if="showArticleSummary" class="d-flex mt-4 text-subtitle"> {{ item?.properties?.summary }} </div>
-          <div class="mt-2 align-self-center text-subtitle font-weight-bold primary--text">{{ $t('news.cards.readMore') }}</div>
-        </a>
-      </div>
-      <div v-if="showArticleReactions" class="bottom-row border-top-color pa-2 width-full b-0 position-absolute white-background text-subtitle">
-        <div class="d-flex text-truncate text-no-wrap">
-          <a
-            class="width-fit-content"
-            target="_self"
-            :href="activityReactionsLink">
-            <div class="d-flex text-truncate text-subtitle">
-              <v-icon
-                size="14">mdi-thumb-up</v-icon>
-              <div class="likes-count ms-1">{{ item.likesCount }}</div>
-              <v-icon
-                class="counters-icons mt-1 ml-2"
-                size="14">
-                mdi-comment
-              </v-icon>
-              <div class="comments-count ms-1">{{ item.commentsCount }}</div>
-            </div>
-          </a>
-          <a
-            class="articleLink"
-            target="_self"
-            :href="activityReactionsLink">
-            <div class="views">
-              <v-icon
-                class="counters-icons"
-                size="16">mdi-eye</v-icon>
-              <div class="views-count ms-1">{{ item.viewsCount }}</div>
-            </div>
-          </a>
+          <div
+            v-if="showArticleSummary"
+            class="d-flex mt-4 text-subtitle">
+            {{ item?.properties?.summary }}
+          </div>
+          <div
+            class="mt-2 align-self-center text-subtitle font-weight-bold primary--text">
+            {{ $t('news.cards.readMore') }}
+          </div>
         </div>
       </div>
     </div>
-  </div>
+    <div
+      v-if="showArticleReactions"
+      class="bottom-row border-top-color pa-2 width-full b-0 position-absolute white-background text-subtitle">
+      <div class="d-flex text-truncate text-no-wrap">
+        <div class="width-fit-content">
+          <div class="d-flex text-truncate text-subtitle">
+            <v-icon size="14">mdi-thumb-up</v-icon>
+            <span class="screen-reader-only">
+              {{ $t('news.app.number.likes') }}
+            </span>
+            <div class="likes-count ms-1">
+              {{ item.likesCount }}
+            </div>
+            <v-icon class="counters-icons mt-1 ml-2" size="14">
+              mdi-comment
+            </v-icon>
+            <span class="screen-reader-only">
+              {{ $t('news.app.number.comments') }}
+            </span>
+            <div class="comments-count ms-1">
+              {{ item.commentsCount }}
+            </div>
+          </div>
+        </div>
+        <div class="articleLink">
+          <div class="views">
+            <v-icon class="counters-icons" size="16">mdi-eye</v-icon>
+            <span class="screen-reader-only">
+              {{ $t('news.app.number.views') }}
+            </span>
+            <div class="views-count ms-1">
+              {{ item.viewsCount }}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </a>
 </template>
 
 <script>
@@ -123,6 +140,9 @@ export default {
       month: 'long',
       day: 'numeric',
     },
+    slideActive: false,
+    tabConsumed: false,
+    hasFocus: false   
   }),
   computed: {
     displayDate() {
@@ -161,12 +181,46 @@ export default {
     isHiddenSpace() {
       return this.item && !this.item.spaceMember && this.item.hiddenSpace;
     },
-    activityReactionsLink() {
-      return this.item && `${this.item.url}#activityReactions`;
-    },
     articleUrl() {
       return eXo.env.portal.userName !== '' ? this.item.url : `${eXo.env.portal.context}/${eXo.env.portal.portalName}/news-detail?newsId=${this.item.id}&type=article`;
     }
+  },
+  methods: {
+    onCardFocus() {
+      this.hasFocus = true;
+    },
+
+    onCardBlur() {
+      this.hasFocus = false;
+      this.slideActive = false;
+      this.tabConsumed = false;
+    },
+
+    onCardKeydown(e) {
+      if (e.key === 'Enter') {
+        return;
+      }
+      if (e.key === 'Tab') {
+        const isShift = e.shiftKey;
+        if (!this.tabConsumed && !isShift) {
+          e.preventDefault();
+          this.slideActive = true;
+          this.tabConsumed = true;
+          return;
+        }
+        if (this.tabConsumed && !isShift) {
+          this.tabConsumed = false;
+          this.slideActive = false;
+          return;
+        }
+        if (isShift) {
+          this.tabConsumed = false;
+          this.slideActive = false;
+          return;
+        }
+      }
+    }
   }
+
 };
 </script>


### PR DESCRIPTION
Before this change, when navigating using the tab in the list of articles, we could focus on each detail of an article. After this commit, the tab navigation is changed to focus on the whole article, and tab press moved to the next article; also, pressing enter opens the selected article in the same tab.