### PR TITLE
fix: Having an accessible name for additional content of articles displayed in cards template - MEED-9952 - Meeds-io/meeds#3844

### DIFF
--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsCardsView.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsCardsView.vue
@@ -27,7 +27,6 @@
         :item="item"
         :selected-option="selectedOption"
         tabindex="0"
-        role="article"
         :aria-label="$t('news.illustration.link.title', {0: item.title})" />
     </card-carousel>
   </div>

--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsCardsViewItem.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsCardsViewItem.vue
@@ -36,7 +36,9 @@
         class="article-illustration-img">
     </div>
     <div class="text-area">
-      <div class="upper-row">
+      <a
+        class="upper-row"
+        :aria-label="$t('news.illustration.link.title', {0: item.title})">
         <div
           v-if="!isHiddenSpace && showArticleSpace"
           :id="`space-link-${item.activityId}`"
@@ -77,7 +79,7 @@
             {{ $t('news.cards.readMore') }}
           </div>
         </div>
-      </div>
+      </a>
     </div>
     <div
       v-if="showArticleReactions"


### PR DESCRIPTION
This commit adds a label area to the sliding content on a news card.