### PR TITLE
fix: Fix the reaction bar of articles cards when hovering on the sidebar - MEED-9955 - Meeds-io/meeds#3845

### DIFF
--- a/content-webapp/src/main/webapp/skin/less/newsListView.less
+++ b/content-webapp/src/main/webapp/skin/less/newsListView.less
@@ -1278,7 +1278,6 @@ p.caption-title:after {
     left: 0;
     width: 100%;
     box-sizing: border-box;
-    z-index: 10;
   }
 
   .article-counters {


### PR DESCRIPTION
Prior to this change, when hovering on the sidebar, the reactions bar of articles cards appears. This change will fix this wrong display.