### PR TITLE
fix: Keep the border on image only when tabbing - Meeds-io/MIPs#232 

### DIFF
--- a/content-webapp/src/main/webapp/vue-app/image/components/view/ImageView.vue
+++ b/content-webapp/src/main/webapp/vue-app/image/components/view/ImageView.vue
@@ -26,9 +26,7 @@
       rel,
     }"
     :is="linkUrl ? 'a' : 'div'"
-    class="d-block full-width full-height"
-    @focus="onFocus"
-    @blur="isFocused = false">
+    class="d-block full-width full-height">
     <img
       v-if="$root.imageUrl"
       :src="$root.imageUrl"
@@ -36,19 +34,13 @@
       :aria-label="(!!linkUrl && !$root.imageAltText) ? $t('image.label.accessLink') : null"
       :width="$root.fixedHeight && `${width}px` || '100%'"
       :height="$root.fixedHeight && `${$root.fixedHeight}px` || '100%'"
-      :class="[cssClass, imageFocusCss]"
+      :class="cssClass"
       :style="cssStyle"
       class="border-box-sizing">
   </component>
 </template>
 <script>
 export default {
-  data() {
-    return {
-      isFocused: false,
-      isTabbing: false
-    };
-  },
   computed: {
     appWidth() {
       return this.$root.imageAspectRatio * this.$root.imageHeight;
@@ -89,32 +81,6 @@ export default {
     },
     rel() {
       return this.$root.imageLinkTarget === '_blank' && 'noopener noreferrer' || null;
-    },
-    imageFocusCss() {
-      return this.isFocused && 'border-primary-dashed';
-    }
-  },
-  mounted() {
-    window.addEventListener('keydown', this.onKeyDown);
-    window.addEventListener('mousedown', this.onMouseDown);
-  },
-  beforeDestroy() {
-    window.removeEventListener('keydown', this.onKeyDown);
-    window.removeEventListener('mousedown', this.onMouseDown);
-  },
-  methods: {
-    onKeyDown(e) {
-      if (e.key === 'Tab') {
-        this.isTabbing = true;
-      }
-    },
-    onMouseDown() {
-      this.isTabbing = false;
-    },
-    onFocus() {
-      if (this.isTabbing) {
-        this.isFocused = true;
-      }
     }
   }
 };

--- a/content-webapp/src/main/webapp/vue-app/image/components/view/ImageView.vue
+++ b/content-webapp/src/main/webapp/vue-app/image/components/view/ImageView.vue
@@ -27,7 +27,7 @@
     }"
     :is="linkUrl ? 'a' : 'div'"
     class="d-block full-width full-height"
-    @focus="isFocused = true"
+    @focus="onFocus"
     @blur="isFocused = false">
     <img
       v-if="$root.imageUrl"
@@ -45,7 +45,8 @@
 export default {
   data() {
     return {
-      isFocused: false
+      isFocused: false,
+      isTabbing: false
     };
   },
   computed: {
@@ -91,6 +92,29 @@ export default {
     },
     imageFocusCss() {
       return this.isFocused && 'border-primary-dashed';
+    }
+  },
+  mounted() {
+    window.addEventListener('keydown', this.onKeyDown);
+    window.addEventListener('mousedown', this.onMouseDown);
+  },
+  beforeDestroy() {
+    window.removeEventListener('keydown', this.onKeyDown);
+    window.removeEventListener('mousedown', this.onMouseDown);
+  },
+  methods: {
+    onKeyDown(e) {
+      if (e.key === 'Tab') {
+        this.isTabbing = true;
+      }
+    },
+    onMouseDown() {
+      this.isTabbing = false;
+    },
+    onFocus() {
+      if (this.isTabbing) {
+        this.isFocused = true;
+      }
     }
   }
 };


### PR DESCRIPTION
This change will keep the border on image only when tabbing.