### PR TITLE
fix: Content slider traget details vertical alignement not centered - MEED-10107 - Meeds-io/meeds#3964

### DIFF
--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsSliderView.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsSliderView.vue
@@ -41,7 +41,7 @@
             :alt="item?.properties?.featuredImage?.altText || ''"
             class="articleImage object-fit-cover width-full full-height">
           <v-container class="slide-text-container d-flex text-center">
-            <div class="flex flex-column carouselNewsInfo">
+            <div class="flex d-flex flex-column carouselNewsInfo">
               <div
                 :class="$vuetify.rtl && 'l-0' || 'r-0'"
                 class="flex flex-row position-absolute">


### PR DESCRIPTION
prior to this change, the content slider info wasn't vertically centered due to missing flex css property, This PR ensures to add the needed class helper to vertically center the details.