### PR TITLE
fix: blur news card hover on Escape - MEED-10115 - Meeds-io/meeds#3977

### DIFF
--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsCardsViewItem.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsCardsViewItem.vue
@@ -21,9 +21,11 @@
 <template>
   <a
     class="card card-border-radius"
+    ref="newsCard"
     :href="articleUrl"
     target="_self"
     :class="{ 'keyboard-slide': slideActive }"
+    @keydown.esc="blurContentHover($event)"
     tabindex="0">
     <div class="imgContainer">
       <img
@@ -187,6 +189,10 @@ export default {
   methods: {
     openArticle() {
       window.open(this.articleUrl, '_self');
+    },
+    blurContentHover(event) {
+      event.target.blur();
+      this.$refs.newsCard.focus();
     }
   }
 };


### PR DESCRIPTION
Prior to this change, navigating to the news card content using the Tab key triggered the hover effect, and there was no way to exit this state without moving the focus to the next card. This update blurs the news card hover on Escape, resolving the issue