### PR TITLE
fix: Lose focus on addditionnal content - MEED-10140 - Meeds-io/meeds#3992

### DIFF
--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsCardsViewItem.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsCardsViewItem.vue
@@ -38,8 +38,11 @@
       tabindex="0"
       role="link"
       :aria-label="$t('news.illustration.link.title', {0: item.title})"
+      @focus="isArticleLinkFocused=true"
+      @blur="isArticleLinkFocused=false"
       @keydown.enter.prevent="openArticle">
       <div
+        :class="isArticleLinkFocused ? 'border-color-black' : ''"
         class="upper-row">
         <div
           v-if="!isHiddenSpace && showArticleSpace"
@@ -144,6 +147,7 @@ export default {
       day: 'numeric',
     },
     slideActive: false,
+    isArticleLinkFocused: false,
   }),
   computed: {
     displayDate() {


### PR DESCRIPTION
Before this change, when Add some articles in cards template then first Tab into any article to focus the whole article and second Tab to trigger the hover effect for the additional content, the focus is lost and the black border is no more displayed on the additional content. To fix this problem, add the class border-color-black if the item aticle link is focused. After this change, the black border is displayed when focusing the additional content.