### PR TITLE
feat: Retrieve Memberships from User ACL instead of OrganizationService - MEED-10149 - Meeds-io/MIPs#240

### DIFF
--- a/content-service/src/main/java/io/meeds/content/link/plugin/LinkSettingTranslationPlugin.java
+++ b/content-service/src/main/java/io/meeds/content/link/plugin/LinkSettingTranslationPlugin.java
@@ -18,19 +18,13 @@
  */
 package io.meeds.content.link.plugin;
 
-import java.util.List;
-
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import org.exoplatform.commons.exception.ObjectNotFoundException;
+import org.exoplatform.portal.config.UserACL;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
-import org.exoplatform.services.organization.OrganizationService;
-import org.exoplatform.services.security.Identity;
-import org.exoplatform.services.security.IdentityRegistry;
-import org.exoplatform.services.security.MembershipEntry;
 
 import io.meeds.content.link.model.LinkSetting;
 import io.meeds.content.link.service.LinkService;
@@ -42,21 +36,18 @@ import jakarta.annotation.PostConstruct;
 @Component
 public class LinkSettingTranslationPlugin extends TranslationPlugin {
 
-  public static final String    LINK_SETTINGS_OBJECT_TYPE = "link-settings";
+  public static final String   LINK_SETTINGS_OBJECT_TYPE = "link-settings";
 
-  private static final Log      LOG                       = ExoLogger.getLogger(LinkSettingTranslationPlugin.class);
-
-  @Autowired
-  protected LinkService         linkService;
+  private static final Log     LOG                       = ExoLogger.getLogger(LinkSettingTranslationPlugin.class);
 
   @Autowired
-  protected IdentityRegistry    identityRegistry;
+  protected LinkService        linkService;
 
   @Autowired
-  protected OrganizationService organizationService;
+  protected TranslationService translationService;
 
   @Autowired
-  protected TranslationService  translationService;
+  protected UserACL            userAcl;
 
   @PostConstruct
   public void init() {
@@ -72,7 +63,7 @@ public class LinkSettingTranslationPlugin extends TranslationPlugin {
   public boolean hasAccessPermission(String linkSettingId, String username) throws ObjectNotFoundException {
     try {
       LinkSetting linkSetting = linkService.getLinkSettingById(Long.parseLong(linkSettingId));
-      return linkSetting != null && linkService.hasAccessPermission(linkSetting.getName(), getIdentity(username));
+      return linkSetting != null && linkService.hasAccessPermission(linkSetting.getName(), userAcl.getUserIdentity(username));
     } catch (Exception e) {
       LOG.warn("Error checking access permission on link setting with id {} for user {}", linkSettingId, username, e);
       return false;
@@ -83,7 +74,7 @@ public class LinkSettingTranslationPlugin extends TranslationPlugin {
   public boolean hasEditPermission(String linkSettingId, String username) throws ObjectNotFoundException {
     try {
       LinkSetting linkSetting = linkService.getLinkSettingById(Long.parseLong(linkSettingId));
-      return linkSetting != null && linkService.hasEditPermission(linkSetting.getName(), getIdentity(username));
+      return linkSetting != null && linkService.hasEditPermission(linkSetting.getName(), userAcl.getUserIdentity(username));
     } catch (Exception e) {
       LOG.warn("Error checking edit permission on link setting with id {} for user {}", linkSettingId, username, e);
       return false;
@@ -100,21 +91,4 @@ public class LinkSettingTranslationPlugin extends TranslationPlugin {
     return 0;
   }
 
-  private Identity getIdentity(String username) throws Exception {
-    if (StringUtils.isBlank(username)) {
-      return null;
-    }
-    Identity aclIdentity = identityRegistry.getIdentity(username);
-    if (aclIdentity == null) {
-      List<MembershipEntry> entries = organizationService.getMembershipHandler()
-                                                         .findMembershipsByUser(username)
-                                                         .stream()
-                                                         .map(membership -> new MembershipEntry(membership.getGroupId(),
-                                                                                                membership.getMembershipType()))
-                                                         .toList();
-      aclIdentity = new Identity(username, entries);
-      identityRegistry.register(aclIdentity);
-    }
-    return aclIdentity;
-  }
 }

--- a/content-service/src/main/java/io/meeds/content/link/plugin/LinkTranslationPlugin.java
+++ b/content-service/src/main/java/io/meeds/content/link/plugin/LinkTranslationPlugin.java
@@ -18,19 +18,13 @@
  */
 package io.meeds.content.link.plugin;
 
-import java.util.List;
-
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import org.exoplatform.commons.exception.ObjectNotFoundException;
+import org.exoplatform.portal.config.UserACL;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
-import org.exoplatform.services.organization.OrganizationService;
-import org.exoplatform.services.security.Identity;
-import org.exoplatform.services.security.IdentityRegistry;
-import org.exoplatform.services.security.MembershipEntry;
 
 import io.meeds.content.link.model.LinkSetting;
 import io.meeds.content.link.service.LinkService;
@@ -50,13 +44,10 @@ public class LinkTranslationPlugin extends TranslationPlugin {
   private LinkService         linkService;
 
   @Autowired
-  private IdentityRegistry    identityRegistry;
-
-  @Autowired
-  private OrganizationService organizationService;
-
-  @Autowired
   private TranslationService  translationService;
+
+  @Autowired
+  protected UserACL            userAcl;
 
   @PostConstruct
   public void init() {
@@ -72,7 +63,7 @@ public class LinkTranslationPlugin extends TranslationPlugin {
   public boolean hasAccessPermission(String linkId, String username) throws ObjectNotFoundException {
     try {
       LinkSetting linkSetting = linkService.getLinkSettingByLinkId(Long.parseLong(linkId));
-      return linkSetting != null && linkService.hasAccessPermission(linkSetting.getName(), getIdentity(username));
+      return linkSetting != null && linkService.hasAccessPermission(linkSetting.getName(), userAcl.getUserIdentity(username));
     } catch (Exception e) {
       LOG.warn("Error checking access permission on link with id {} for user {}", linkId, username, e);
       return false;
@@ -83,7 +74,7 @@ public class LinkTranslationPlugin extends TranslationPlugin {
   public boolean hasEditPermission(String linkId, String username) throws ObjectNotFoundException {
     try {
       LinkSetting linkSetting = linkService.getLinkSettingByLinkId(Long.parseLong(linkId));
-      return linkSetting != null && linkService.hasEditPermission(linkSetting.getName(), getIdentity(username));
+      return linkSetting != null && linkService.hasEditPermission(linkSetting.getName(), userAcl.getUserIdentity(username));
     } catch (Exception e) {
       LOG.warn("Error checking edit permission on link with id {} for user {}", linkId, username, e);
       return false;
@@ -100,21 +91,4 @@ public class LinkTranslationPlugin extends TranslationPlugin {
     return 0;
   }
 
-  private Identity getIdentity(String username) throws Exception {
-    if (StringUtils.isBlank(username)) {
-      return null;
-    }
-    Identity aclIdentity = identityRegistry.getIdentity(username);
-    if (aclIdentity == null) {
-      List<MembershipEntry> entries = organizationService.getMembershipHandler()
-                                                         .findMembershipsByUser(username)
-                                                         .stream()
-                                                         .map(membership -> new MembershipEntry(membership.getGroupId(),
-                                                                                                membership.getMembershipType()))
-                                                         .toList();
-      aclIdentity = new Identity(username, entries);
-      identityRegistry.register(aclIdentity);
-    }
-    return aclIdentity;
-  }
 }

--- a/content-service/src/main/java/io/meeds/content/news/plugin/NewsListViewTranslationPlugin.java
+++ b/content-service/src/main/java/io/meeds/content/news/plugin/NewsListViewTranslationPlugin.java
@@ -28,6 +28,7 @@ import org.exoplatform.commons.api.settings.SettingService;
 import org.exoplatform.commons.api.settings.SettingValue;
 import org.exoplatform.commons.exception.ObjectNotFoundException;
 import org.exoplatform.container.ExoContainerContext;
+import org.exoplatform.portal.config.UserACL;
 import org.exoplatform.services.organization.OrganizationService;
 import org.exoplatform.services.security.Identity;
 import org.exoplatform.services.security.IdentityRegistry;
@@ -46,13 +47,6 @@ public class NewsListViewTranslationPlugin extends TranslationPlugin {
 
   public static final String        NEWS_LIST_VIEW_OBJECT_TYPE      = "newsListView";
   
-
-  @Setter
-  private IdentityRegistry    identityRegistry;
-
-  @Autowired
-  private OrganizationService organizationService;
-
   @Autowired
   private TranslationService  translationService;
 
@@ -62,9 +56,11 @@ public class NewsListViewTranslationPlugin extends TranslationPlugin {
   @Autowired
   private SettingService      settingService;
 
+  @Autowired
+  private UserACL            userAcl;
+
   @PostConstruct
   public void init() {
-    setIdentityRegistry(ExoContainerContext.getService(IdentityRegistry.class));
     translationService.addPlugin(this);
   }
 
@@ -90,8 +86,9 @@ public class NewsListViewTranslationPlugin extends TranslationPlugin {
                                                             NewsUtils.NEWS_LIST_VIEW_SCOPE,
                                                             objectId);
       String settingName = settingNameValue != null ? settingNameValue.getValue().toString() : null;
-      return getIdentity(username) != null
-          && (cmsService.hasEditPermission(getIdentity(username), "newsListViewPortlet", settingName));
+      Identity userAclIdentity = userAcl.getUserIdentity(username);
+      return userAclIdentity != null
+             && (cmsService.hasEditPermission(userAclIdentity, "newsListViewPortlet", settingName));
     } catch (Exception e) {
       return false;
     }
@@ -107,21 +104,4 @@ public class NewsListViewTranslationPlugin extends TranslationPlugin {
     return 0;
   }
 
-  private Identity getIdentity(String username) throws Exception {
-    if (StringUtils.isBlank(username)) {
-      return null;
-    }
-    Identity aclIdentity = identityRegistry.getIdentity(username);
-    if (aclIdentity == null) {
-      List<MembershipEntry> entries = organizationService.getMembershipHandler()
-                                                         .findMembershipsByUser(username)
-                                                         .stream()
-                                                         .map(membership -> new MembershipEntry(membership.getGroupId(),
-                                                                                                membership.getMembershipType()))
-                                                         .toList();
-      aclIdentity = new Identity(username, entries);
-      identityRegistry.register(aclIdentity);
-    }
-    return aclIdentity;
-  }
 }


### PR DESCRIPTION
This change will centralize the users memberships retrieval to be made from `UserACL` Service rather than `OrganizationService`. This centralization will allow to optimize the Code enhancements and evolutivity.