### PR TITLE
fix: improve target selection in news list configuration - MEED-10277 - Meeds-io/meeds#4076

### DIFF
--- a/content-service/src/main/resources/locale/portlet/news/News_en.properties
+++ b/content-service/src/main/resources/locale/portlet/news/News_en.properties
@@ -247,6 +247,7 @@ news.newsTarget.message.confirmDeleteNews=You are about to delete the target. Th
 news.newsTarget.title.confirmDeleteNews=Target deletion
 news.newsTarget.confirmDeleteNews.button.delete=Delete
 news.newsTarget.confirmDeleteNews.cancel=Cancel
+news.newsTarget.selector.placeholder=Search for a target
 
 news.publishTargets.management.addTarget=Add a target
 news.publishTargets.management.editTarget=Edit a target

--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/settings/NewsSettingsDrawer.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/settings/NewsSettingsDrawer.vue
@@ -88,26 +88,7 @@
           </div>
           <div class="d-flex flex-row infosLabel font-italic">{{ $t('news.list.settings.newsTargets.description') }}</div>
           <div class="d-flex flex-row">
-            <v-select
-              id="newsTargetRefs"
-              ref="newsTargetRefs"
-              v-model="newsTarget"
-              :items="newsTargets"
-              :menu-props="{ bottom: true, offsetY: true}"
-              :disabled="!newsTargets.length"
-              :background-color="backgroundColor"
-              item-text="label"
-              item-value="name"
-              dense
-              outlined
-              class="pa-0"
-              @blur="blurSelection">
-              <template #selection="{ item }">
-                <span :title="item.toolTipInfo">
-                  {{ item.label }}
-                </span>
-              </template>
-            </v-select>
+            <news-target-suggester v-model="newsTarget" :allowed-targets="newsTargets" />
           </div>
           <div v-if="$root.canManageNewsTarget" class="d-flex flex-row clickable text-decoration-underline">
             <a @click="createNewTarget"> {{ $t('news.list.settings.drawer.createNewTarget') }} </a>

--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/settings/NewsTargetSuggester.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/settings/NewsTargetSuggester.vue
@@ -1,0 +1,89 @@
+<!--
+
+ This file is part of the Meeds project (https://meeds.io/).
+
+ Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 3 of the License, or (at your option) any later version.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public License
+ along with this program; if not, write to the Free Software Foundation,
+ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+-->
+<template>
+  <v-autocomplete
+    ref="selectAutoComplete"
+    v-model="value"
+    :items="newsTargetItems"
+    :placeholder="$t('news.newsTarget.selector.placeholder')"
+    append-icon=""
+    menu-props="closeOnClick, closeOnContentClick, maxHeight = 100"
+    class="identitySuggester identitySuggesterInputStyle"
+    content-class="identitySuggesterContent"
+    width="100%"
+    max-width="100%"
+    item-text="label"
+    item-value="name"
+    chips
+    dense
+    flat
+    required
+    @update:search-input="searchTerm = $event">
+    <template #no-data>
+      <v-list-item class="pa-0">
+        <v-list-item-title
+          class="px-2">
+          {{ $t('newsTargets.settings.noTargets') }}
+        </v-list-item-title>
+      </v-list-item>
+    </template>
+    <template #selection="{ item }">
+      <span :title="item.toolTipInfo">
+        {{ item.label }}
+      </span>
+    </template>
+    <template #item="{ item }">
+      <v-list-item-title class="text-truncate">
+        {{ item.label }}
+      </v-list-item-title>
+    </template>
+  </v-autocomplete>
+</template>
+
+<script>
+export default {
+  props: {
+    value: {
+      type: Object,
+      default: null
+    },
+    allowedTargets: {
+      type: Array,
+      default: () => []
+    }
+  },
+  data() {
+    return {
+      searchTerm: null,
+    };
+  },
+  computed: {
+    newsTargetItems() {
+      return this.allowedTargets;
+    },
+  },
+  watch: {
+    value() {
+      this.$emit('input', this.value);
+    },
+  },
+};
+</script>

--- a/content-webapp/src/main/webapp/vue-app/news-list-view/initComponents.js
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/initComponents.js
@@ -34,6 +34,7 @@ import NewsStoriesView from './components/views/NewsStoriesView.vue';
 import NewsStoriesViewItem from './components/views/NewsStoriesViewItem.vue';
 import NewsCardsView from './components/views/NewsCardsView.vue';
 import NewsCardsViewItem from './components/views/NewsCardsViewItem.vue';
+import NewsTargetSuggester from './components/settings/NewsTargetSuggester.vue';
 
 
 const components = {
@@ -54,6 +55,7 @@ const components = {
   'news-stories-view-item': NewsStoriesViewItem,
   'news-cards-view': NewsCardsView,
   'news-cards-view-item': NewsCardsViewItem,
+  'news-target-suggester': NewsTargetSuggester
 };
 
 for (const key in components) {


### PR DESCRIPTION
Prior to this change, the news list settings target selector used the v-select component, which made searching for a target by typing impossible. This change replaces it with the v-autocomplete component, ensuring that news targets are searchable in the selector.