### PR TITLE
fix: External-link-alt icon displayed in links must inheritate text-body style - MEED-10294 - Meeds-io/meeds#4084

### DIFF
--- a/content-webapp/src/main/webapp/vue-app/links/components/view/LinksColumn.vue
+++ b/content-webapp/src/main/webapp/vue-app/links/components/view/LinksColumn.vue
@@ -41,7 +41,7 @@
         {{ name }}
         <v-icon
           v-if="!link.sameTab"
-          class="mt-n1"
+          class="mt-n1 text-color"
           size="12">
           fa-external-link-alt
         </v-icon>


### PR DESCRIPTION
Before this change, when add several links that open in new tab then change the links portlet settings and set content color, the icon displayed isn't the same color as the content. to fix this issue, add the class text-color to link icon. after this change, the content color is applied on the icon.
Resolves https://github.com/Meeds-io/meeds/issues/4084