### PR TITLE
fix: Restrict news metadata parameters updates to dedicated endpoint only - EXO-86412 - exoplatform/eXIP#41

### DIFF
--- a/content-service/src/main/java/io/meeds/content/news/rest/NewsRest.java
+++ b/content-service/src/main/java/io/meeds/content/news/rest/NewsRest.java
@@ -231,7 +231,6 @@ public class NewsRest {
       news.setProperties(updatedNews.getProperties());
       news.setLang(updatedNews.getLang());
       news.setReferred(updatedNews.isReferred());
-      news.setParameters(updatedNews.getParameters());
       news = newsService.updateNews(news,
                                     currentIdentity.getUserId(),
                                     post,


### PR DESCRIPTION
Restrict news metadata parameters updates to dedicated endpoint only