### PR TITLE
feat: Add ContentType Definition in Search Connector - EXO-86376

### DIFF
--- a/content-webapp/src/main/webapp/WEB-INF/conf/news/search-configuration.xml
+++ b/content-webapp/src/main/webapp/WEB-INF/conf/news/search-configuration.xml
@@ -37,6 +37,9 @@
             <field name="name">
               <string>news</string>
             </field>
+            <field name="contentType">
+              <string>news</string>
+            </field>
             <field name="uri">
               <string><![CDATA[/content/rest/contents/search?query={keyword}&limit={limit}]]></string>
             </field>


### PR DESCRIPTION
This change will allow to define the associated `contentType` for each Search Connector to allow automatic filtering on content types.