### PR TITLE
fix: Enhance new list labels - EXO-87160 - Meeds-io/meeds#4177 (#740)

### DIFF
--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/settings/NewsSettingsDrawer.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/settings/NewsSettingsDrawer.vue
@@ -47,7 +47,7 @@
         <div v-if="!showAdvancedSettings" class="d-flex flex-column flex-grow-1">
           <div class="d-flex flex-column">
             <label for="headerName" class="text-header me-1 my-4">
-              {{ $t('news.list.settings.header') }}:
+              {{ $t('news.list.settings.header') }}
             </label>
             <translation-text-field
               ref="headerNameInput"
@@ -70,7 +70,7 @@
             @update-source-option="updateArticlesSourceOption" />
           <div class="flex-column">
             <label for="viewTemplate" class="text-header my-4">
-              {{ $t('news.list.settings.blockDisplay') }}:
+              {{ $t('news.list.settings.blockDisplay') }}
             </label>
             <v-select
               id="viewTemplate"


### PR DESCRIPTION
Prior to this change, some labels have ":" in their values but it is not available on crowdin.
To enhance that, we have removed the ":" from the vuejs files and added them to labels values to let update them possible from crowdin.

Resolves https://github.com/Meeds-io/meeds/issues/4177