### PR TITLE
fix: Fix categories lost when publishing and edit publishing an article or a note - MEED-10444 - Meeds-io/meeds#4249 

### DIFF
--- a/content-service/src/main/java/io/meeds/content/news/service/NewsService.java
+++ b/content-service/src/main/java/io/meeds/content/news/service/NewsService.java
@@ -402,7 +402,7 @@ public class NewsService {
     }
     if (!news.getPublicationState().isEmpty() && !DRAFT.equals(news.getPublicationState())) {
       if (post != null) {
-        updateNewsActivity(news, post, originalNews.isActivityPosted());
+        updateNewsActivity(news, post, originalNews.isActivityPosted(), true);
       }
       NewsUtils.broadcastEvent(NewsUtils.UPDATE_NEWS, updater, news);
       NewsUtils.broadcastEvent(NewsUtils.UPDATE_PUBLISH_CONTENT, updater, new ContentPublishEvent(originalNews, news));
@@ -1430,7 +1430,7 @@ public class NewsService {
       mergedProperties.putAll(properties);
       existingItem.setProperties(mergedProperties);
       metadataService.updateMetadataItem(existingItem, updater, false);
-      updateNewsActivity(article, false, article.isActivityPosted());
+      updateNewsActivity(article, false, article.isActivityPosted(), false);
       article.setParameters(mergedProperties);
       NewsUtils.broadcastEvent(NewsUtils.UPDATE_NEWS, updater, article);
       return mergedProperties;
@@ -2115,7 +2115,7 @@ public class NewsService {
     }
   }
 
-  private void updateNewsActivity(News news, boolean post, boolean isPosted) {
+  private void updateNewsActivity(News news, boolean post, boolean isPosted, boolean linkCategories) {
     ExoSocialActivity activity = activityManager.getActivity(news.getActivityId());
     if (activity != null) {
       if (post && !isPosted) {
@@ -2128,7 +2128,9 @@ public class NewsService {
       activity.setMetadataObjectId(news.getId());
       activity.setMetadataObjectType(NewsUtils.NEWS_METADATA_OBJECT_TYPE);
       activityManager.updateActivity(activity, false);
-      linkActivityCategories(activity, news.getCategories());
+      if (linkCategories) {
+        linkActivityCategories(activity, news.getCategories());
+      }
     }
   }
 

--- a/content-webapp/src/main/webapp/vue-app/news-details/components/ExoNewsDetails.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-details/components/ExoNewsDetails.vue
@@ -382,7 +382,7 @@ export default {
       } else {
         const successMessage = this.$t('notes.publication.settings.update.success');
         const errorMessage = this.$t('notes.publication.settings.update.error');
-
+        document.dispatchEvent(new Event('closeDisplayedDrawer'));
         this.publish(editScheduleAction, scheduleSettings).then(async (article) => {
           this.displayMessage({message: successMessage, type: 'success'});
           history.replaceState({}, article.url);
@@ -391,7 +391,6 @@ export default {
         }).catch(() => {
           this.displayMessage({message: errorMessage, type: 'error'});
         }).finally(() => {
-          this.$refs?.publicationDrawer?.close?.();
           this.isPublishing = false;
         });
       }


### PR DESCRIPTION
Prior to this change, when publishing or edit publishing an article or a note, the categories are lost which is caused by a double link categories done with an empty list.
After this commit, we ensure to avoid this double linking in order to not lose the set categories.

Resolves https://github.com/Meeds-io/meeds/issues/4249