### PR TITLE
fix: improve CTA news extension display latency in the space activity stream - EXO-87165

### DIFF
--- a/content-webapp/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/content-webapp/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -491,9 +491,6 @@
     <depends>
       <module>commonVueComponents</module>
     </depends>
-    <depends>
-      <module>newsDetails</module>
-    </depends>
   </module>
 
   <module>
@@ -665,6 +662,18 @@
     </depends>
     <depends>
       <module>commonVueComponents</module>
+    </depends>
+  </module>
+
+  <module>
+    <name>NewsDetailsActivityStreamExtensions</name>
+    <load-group>ActivityStreamGRP</load-group>
+    <script>
+      <minify>false</minify>
+      <path>/js/newsActivityStreamExtensions.bundle.js</path>
+    </script>
+    <depends>
+      <module>newsDetails</module>
     </depends>
   </module>
 

--- a/content-webapp/src/main/webapp/vue-app/news-extensions/activity-stream-extensions/extensions.js
+++ b/content-webapp/src/main/webapp/vue-app/news-extensions/activity-stream-extensions/extensions.js
@@ -17,11 +17,7 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
-
 const lang = eXo.env.portal.language || 'en';
-const url = `/content/i18n/locale.portlet.news.News?lang=${lang}`;
-
-const i18nPromise = exoi18n.loadLanguageAsync(lang, url).then(i18n => new Vue({i18n}));
 
 const newsActivityTypeExtensionOptions = {
   name: 'News',
@@ -109,29 +105,25 @@ export function initExtensions() {
     type: 'news',
     options: newsActivityTypeExtensionOptions,
   });
-  if (eXo.env.portal.spaceId) {
-    Vue.prototype.$newsServices.canUserCreateNews(eXo.env.portal.spaceId).then(canCreateNews => {
-      if (canCreateNews) {
-        return i18nPromise.then(() => {
-          extensionRegistry.registerComponent('ActivityComposerAction', 'activity-composer-action', {
-            id: 'switchNewsButton',
-            vueComponent: Vue.options.components['activity-switch-to-news'],
-            rank: 10,
-          });
-          extensionRegistry.registerComponent('ActivityComposerFooterAction', 'activity-composer-footer-action', {
-            id: 'writeNewsButton',
-            vueComponent: Vue.options.components['activity-write-news-composer'],
-            rank: 30,
-          });
-          extensionRegistry.registerComponent('ActivityToolbarAction', 'activity-toolbar-action', {
-            id: 'writeNewsToolbarButton',
-            vueComponent: Vue.options.components['activity-write-news-toolbar-action'],
-            rank: 30,
-          });
-        });
-      }
-    });
-  }
+  extensionRegistry.registerComponent('ActivityComposerAction', 'activity-composer-action', {
+    id: 'switchNewsButton',
+    vueComponent: Vue.options.components['activity-switch-to-news'],
+    rank: 10,
+    isEnabled: () => !!eXo?.env?.portal?.spaceId
+  });
+  extensionRegistry.registerComponent('ActivityComposerFooterAction', 'activity-composer-footer-action', {
+    id: 'writeNewsButton',
+    vueComponent: Vue.options.components['activity-write-news-composer'],
+    rank: 30,
+    isEnabled: () => !!eXo?.env?.portal?.spaceId
+  });
+  extensionRegistry.registerComponent('ActivityToolbarAction', 'activity-toolbar-action', {
+    id: 'writeNewsToolbarButton',
+    vueComponent: Vue.options.components['activity-write-news-toolbar-action'],
+    rank: 30,
+    isEnabled: () => !!eXo?.env?.portal?.spaceId
+  });
+
 }
 function newsViews(news) {
   if (news?.viewsCount < 1000) {

--- a/content-webapp/src/main/webapp/vue-app/news-extensions/activity-stream-extensions/extensions.js
+++ b/content-webapp/src/main/webapp/vue-app/news-extensions/activity-stream-extensions/extensions.js
@@ -18,6 +18,8 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 const lang = eXo.env.portal.language || 'en';
+const url = `/content/i18n/locale.portlet.news.News?lang=${lang}`;
+const i18nPromise = exoi18n.loadLanguageAsync(lang, url);
 
 const newsActivityTypeExtensionOptions = {
   name: 'News',
@@ -100,7 +102,8 @@ const newsActivityTypeExtensionOptions = {
   reactionEnabled: (activity) => !activity?.news?.properties?.hideReaction
 };
 
-export function initExtensions() {
+export async function initExtensions() {
+  await i18nPromise;
   extensionRegistry.registerExtension('activity', 'type', {
     type: 'news',
     options: newsActivityTypeExtensionOptions,

--- a/content-webapp/src/main/webapp/vue-app/news-extensions/activity-stream-extensions/main.js
+++ b/content-webapp/src/main/webapp/vue-app/news-extensions/activity-stream-extensions/main.js
@@ -27,6 +27,10 @@ if (!Vue.prototype.$newsServices) {
   });
 }
 
-export function init() {
+const lang = eXo.env.portal.language || 'en';
+const url = `/content/i18n/locale.portlet.news.News?lang=${lang}`;
+
+export async function init() {
+  await exoi18n.loadLanguageAsync(lang, url);
   initExtensions();
 }

--- a/content-webapp/src/main/webapp/vue-app/news-extensions/activity-stream-extensions/main.js
+++ b/content-webapp/src/main/webapp/vue-app/news-extensions/activity-stream-extensions/main.js
@@ -27,10 +27,8 @@ if (!Vue.prototype.$newsServices) {
   });
 }
 
-const lang = eXo.env.portal.language || 'en';
-const url = `/content/i18n/locale.portlet.news.News?lang=${lang}`;
+
 
 export async function init() {
-  await exoi18n.loadLanguageAsync(lang, url);
-  initExtensions();
+  await initExtensions();
 }


### PR DESCRIPTION
Prior to this change, the News CTA extension appeared with noticeable
latency compared to other extensions (such as Kudos and Poll), which
were displayed instantly. This issue was caused by an unnecessary
permission check for posting news in the extension declaration, even
though the same check was already performed in the activity stream
composer. This change removes the redundant check.