### PR TITLE
fix: fix error when initializing the news details activity stream extension - EXO-87165

### DIFF
--- a/content-webapp/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/content-webapp/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -675,6 +675,9 @@
     <depends>
       <module>newsDetails</module>
     </depends>
+    <depends>
+      <module>eXoVueI18n</module>
+    </depends>
   </module>
 
 </gatein-resources>


### PR DESCRIPTION
Prior to this change, a console error was displayed when initializing the News Details Activity Stream module:

`Uncaught ReferenceError: exoi18n is not defined`

This error was caused by a missing eXoVueI18n dependency. This change adds the missing dependency, resolving the issue.