### PR TITLE
fix: Fix Notes editor application display issue in edit layout mode - EXO-87312

### DIFF
--- a/content-webapp/src/main/webapp/skin/less/newsComposer.less
+++ b/content-webapp/src/main/webapp/skin/less/newsComposer.less
@@ -21,13 +21,6 @@
 @import "./variables.less";
 @grayDark: #333;
 
-.contentEditorContainer {
-  .layout-section-content {
-    width: 100% !important;
-    padding-left: 0 !important;
-    padding-right: 0 !important;
-  }
-}
 .newsComposer {
   #form_msg_error {
     margin-left: 13px ~'; /** orientation=lt */ ';


### PR DESCRIPTION
Prior to this change, the Notes editor application is not well displayed centered in edit layout mode.
After this commit, some css changes are done in order to adjust the display position of the the Notes editor application.