### PR TITLE
fix: Fix lost publishing and scheduling informations when editing article publishing - EXO-87554_EXO-87555

### DIFF
--- a/content-service/src/main/java/io/meeds/content/news/service/NewsService.java
+++ b/content-service/src/main/java/io/meeds/content/news/service/NewsService.java
@@ -2275,6 +2275,9 @@ public class NewsService {
                                                            .orElse(null);
       if (existingPageMetadataItem != null) {
         Map<String, String> newsPageProperties = existingPageMetadataItem.getProperties();
+        if (MapUtils.isNotEmpty(news.getParameters())) {
+          newsPageProperties.putAll(news.getParameters());
+        }
         if (StringUtils.isNotEmpty(news.getAudience())) {
           newsPageProperties.put(NEWS_AUDIENCE, news.getAudience());
         }
@@ -2295,9 +2298,6 @@ public class NewsService {
           org.exoplatform.social.core.identity.model.Identity publisherIdentity =
                                                                                 identityManager.getOrCreateUserIdentity(updater.getUserId());
           newsPageProperties.put(PUBLISHER, publisherIdentity.getProfile().getFullName());
-        }
-        if (MapUtils.isNotEmpty(news.getParameters())) {
-          newsPageProperties.putAll(news.getParameters());
         }
         existingPageMetadataItem.setProperties(newsPageProperties);
         Date updateDate = Calendar.getInstance().getTime();


### PR DESCRIPTION
Prior to this change, when editing article publising, publishing and scheduling informations are lost caused by news.getParameters() containing old informations and put to newsPageProperties map.
After this commit, we will put publishing and scheduling informations to newsPageProperties map just after putting news.getParameters() map to ensure not losing them after updating the article.