### PR TITLE
fix: Fix lost publishing and scheduling informations when editing article publishing - EXO-87554_EXO-87555

### DIFF
--- a/content-service/src/main/java/io/meeds/content/news/service/NewsService.java
+++ b/content-service/src/main/java/io/meeds/content/news/service/NewsService.java
@@ -2293,9 +2293,6 @@ public class NewsService {
                                                                                 identityManager.getOrCreateUserIdentity(updater.getUserId());
           newsPageProperties.put(PUBLISHER, publisherIdentity.getProfile().getFullName());
         }
-        if (MapUtils.isNotEmpty(news.getParameters())) {
-          newsPageProperties.putAll(news.getParameters());
-        }
         existingPageMetadataItem.setProperties(newsPageProperties);
         Date updateDate = Calendar.getInstance().getTime();
         existingPageMetadataItem.setUpdatedDate(updateDate.getTime());


### PR DESCRIPTION

Prior to this change, when editing article publishing, publishing and scheduling informations are lost caused by news.getParameters() containing old informations unnecessarily put to newsPageProperties map. After this commit, we will nomore put news.getParameters() to newsPageProperties map in order to ensure not losing publishing and scheduling informations after updating the article.