### PR TITLE
fix: Fix publication when editing the scheduling option from between to until - EXO-87309

### DIFF
--- a/content-service/src/main/java/io/meeds/content/news/service/NewsService.java
+++ b/content-service/src/main/java/io/meeds/content/news/service/NewsService.java
@@ -920,6 +920,9 @@ public class NewsService {
                                  currentIdentity.getUserId(),
                                  new ContentPublishEvent(originalArticle, news));
       }
+      if (originalArticle != null && originalArticle.getPublicationState().equalsIgnoreCase(STAGED) && news.getSchedulePostDate() == null) {
+        postNews(originalArticle, originalArticle.getAuthor());
+      }
       return news;
     }
     return null;

--- a/content-webapp/src/main/webapp/vue-app/news-activity-composer-app/components/ContentRichEditor.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-activity-composer-app/components/ContentRichEditor.vue
@@ -25,6 +25,7 @@
       :draft-saving-status="draftSavingStatus"
       :note-id-param="activityId"
       :post-key="postKey"
+      :edit-mode="editMode"
       :body-placeholder="contentFormContentPlaceholder"
       :title-placeholder="contentFormTitlePlaceholder"
       :form-title="contentFormTitle"


### PR DESCRIPTION
Prior to this change, when editing the scheduling option from between to until, no immediate publication is done for the article. After this commit, we ensure to publish the article immediately when switching schedule option from between to until.