### PR TITLE
fix: Display restricted area placeholder instead of notes editor or news editor when the current user can not redact on the space - EXO-87648

### DIFF
--- a/content-webapp/src/main/webapp/WEB-INF/portlet.xml
+++ b/content-webapp/src/main/webapp/WEB-INF/portlet.xml
@@ -34,10 +34,6 @@
       <name>preload.resource.bundles</name>
       <value>locale.portlet.news.News</value>
     </init-param>
-    <init-param>
-      <name>layout-css-class</name>
-      <value>no-layout-style</value>
-    </init-param>
     <expiration-cache>-1</expiration-cache>
     <cache-scope>PUBLIC</cache-scope>
     <supports>

--- a/content-webapp/src/main/webapp/vue-app/news-activity-composer-app/components/ContentRichEditor.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-activity-composer-app/components/ContentRichEditor.vue
@@ -51,6 +51,7 @@
         canSchedule: true,
         allowedTargets: allowedTargets
       }"
+      :can-redact="canRedact"
       :images-download-folder="'DRIVE_ROOT_NODE/News/images'"
       @editor-closed="editorClosed"
       @open-treeview="openTreeView"
@@ -131,6 +132,7 @@ export default {
       autosaveProcessedFromEditorExtension: false,
       allowedTargets: [],
       draftObjectType: 'wikiDraft',
+      canRedact: null,
     };
   },
   watch: {
@@ -202,9 +204,6 @@ export default {
     this.$root.$on('lang-translation-changed', this.changeTranslation);
     this.$root.$on('delete-lang-translation', this.deleteTranslation);
     this.contentFormTitle = this.articleId && this.$t('news.editor.label.edit') || this.$t('news.editor.label.create');
-  },
-  mounted() {
-    this.initEditor();
   },
   methods: {
     processAutoSaveFromEditorExtension(event) {
@@ -666,6 +665,7 @@ export default {
       this.loading = true;
       const space = await this.$newsServices.getSpaceById(this.spaceId);
       this.currentSpace = space;
+      this.canRedact = this.currentSpace?.canRedactOnSpace;
       this.spaceDisplayName = space.displayName;
       this.isSpaceMember = space.isMember;
       this.spaceUrl = this.currentSpace?.prettyName;
@@ -696,6 +696,11 @@ export default {
       this.canPublishArticle = await this.$newsServices.canPublishNews(this.currentSpace.id);
       this.initDone = true;
       this.loading = false;
+      if (this.canRedact) {
+        this.$nextTick(() => {
+          this.initEditor();
+        });
+      }
     },
     async replaceSuggestedUsers(message, mentionedUsers) {
       if (!mentionedUsers) {


### PR DESCRIPTION
Prior to this change, when the connected user can not redact on the current space, the notes-editor and news-editor pages are accessible with errors when creating note or article.
After this commit, a restricted area placeholder will be displayed instead of notes editor and news editor when the connected user can not redact on the current space.