### PR TITLE
fix: prevent News List header from being shared across template instances - EXO-87173 (#778)

### DIFF
--- a/content-service/src/main/java/io/meeds/content/news/plugin/NewsListPortletInstancePreferencePlugin.java
+++ b/content-service/src/main/java/io/meeds/content/news/plugin/NewsListPortletInstancePreferencePlugin.java
@@ -1,0 +1,104 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.content.news.plugin;
+
+import java.util.Collections;
+import java.util.List;
+
+import io.meeds.social.translation.model.TranslationField;
+import io.meeds.social.translation.service.TranslationService;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import org.exoplatform.container.ExoContainerContext;
+import org.exoplatform.portal.config.model.Application;
+import org.exoplatform.portal.pom.spi.portlet.Portlet;
+import org.exoplatform.portal.pom.spi.portlet.Preference;
+
+import io.meeds.layout.model.PortletInstanceContext;
+import io.meeds.layout.model.PortletInstancePreference;
+import io.meeds.layout.plugin.PortletInstancePreferencePlugin;
+import io.meeds.layout.service.PortletInstanceService;
+import io.meeds.social.util.JsonUtils;
+
+import jakarta.annotation.PostConstruct;
+import lombok.SneakyThrows;
+
+@Component
+@Profile("layout")
+public class NewsListPortletInstancePreferencePlugin implements PortletInstancePreferencePlugin {
+
+  private static final String    CMS_SETTING_PREFERENCE_NAME = "applicationId";
+
+  private static final String    DATA_INIT_PREFERENCE_NAME   = "data.init";
+
+  @Autowired
+  private TranslationService    translationService;
+
+  @Autowired(required = false)
+  private PortletInstanceService portletInstanceService;
+
+  @PostConstruct
+  public void init() {
+    if (portletInstanceService == null) {
+      portletInstanceService = ExoContainerContext.getService(PortletInstanceService.class);
+    }
+    portletInstanceService.addPortletInstancePreferencePlugin(this);
+  }
+
+  @Override
+  public String getPortletName() {
+    return "NewsListView";
+  }
+
+  @Override
+  @SneakyThrows
+  public List<PortletInstancePreference> generatePreferences(Application application,
+                                                             Portlet preferences,
+                                                             PortletInstanceContext portletInstanceContext) {
+    String settingName = getCmsSettingName(preferences);
+    if (StringUtils.isBlank(settingName)) {
+      if (preferences != null && preferences.getPreference(DATA_INIT_PREFERENCE_NAME) != null) {
+        return Collections.singletonList(new PortletInstancePreference(DATA_INIT_PREFERENCE_NAME,
+                                                                       preferences.getPreference(DATA_INIT_PREFERENCE_NAME)
+                                                                                  .getValue()));
+      } else {
+        return Collections.emptyList();
+      }
+    }
+    TranslationField translationField = translationService.getTranslationField("newsListView", settingName, "headerNameInput");
+    if (translationField != null) {
+      return Collections.singletonList(new PortletInstancePreference(DATA_INIT_PREFERENCE_NAME,
+                                                                     JsonUtils.toJsonString(translationField)));
+    } else {
+      return Collections.emptyList();
+    }
+  }
+
+  private String getCmsSettingName(Portlet preferences) {
+    if (preferences == null) {
+      return null;
+    }
+    Preference settingNamePreference = preferences.getPreference(CMS_SETTING_PREFERENCE_NAME);
+    return settingNamePreference == null ? null : settingNamePreference.getValue();
+  }
+
+}

--- a/content-webapp/src/main/java/io/meeds/content/portlet/NewsListViewPortlet.java
+++ b/content-webapp/src/main/java/io/meeds/content/portlet/NewsListViewPortlet.java
@@ -30,6 +30,11 @@ import javax.portlet.PortletPreferences;
 import javax.portlet.RenderRequest;
 import javax.portlet.RenderResponse;
 
+import io.meeds.social.translation.model.TranslationField;
+import io.meeds.social.translation.service.TranslationService;
+import io.meeds.social.util.JsonUtils;
+import lombok.SneakyThrows;
+import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import org.exoplatform.commons.api.settings.SettingService;
@@ -47,10 +52,27 @@ public class NewsListViewPortlet extends CMSPortlet {
 
   private SettingService settingService;
 
+  private TranslationService translationService;
+
   @Override
   public void init(PortletConfig config) throws PortletException {
     super.init(config);
     this.contentType = OBJECT_TYPE;
+  }
+
+  @Override
+  @SneakyThrows
+  protected void postSettingInit(PortletPreferences preferences, String name) {
+    String data = preferences.getValue(DATA_INIT_PREFERENCE_NAME, null);
+    String applicationId = getOrCreateApplicationId(preferences);
+    if (StringUtils.isNotBlank(data)) {
+      TranslationField translationField = JsonUtils.fromJsonString(data, TranslationField.class);
+      if (translationField != null && MapUtils.isNotEmpty(translationField.getLabels())) {
+        getTranslationService().saveTranslationLabels(translationField.getObjectType(), applicationId, translationField.getFieldName(), translationField.getLabels(), false);
+      }
+      savePreference(DATA_INIT_PREFERENCE_NAME, null);
+    }
+    initNewsListHeaderTranslationSettings(applicationId, name);
   }
 
   @Override
@@ -70,10 +92,9 @@ public class NewsListViewPortlet extends CMSPortlet {
 
   @Override
   public void doView(RenderRequest request, RenderResponse response) throws PortletException, IOException {
-    super.doView(request, response);
     String applicationId = getOrCreateApplicationId(request.getPreferences());
-    request.setAttribute(APPLICATION_ID, applicationId);
-    initNewsListHeaderTranslationSettings(request);
+    request.getPreferences().setValue(APPLICATION_ID, applicationId);
+    super.doView(request, response);
   }
 
   private String getOrCreateApplicationId(PortletPreferences preferences) {
@@ -86,9 +107,7 @@ public class NewsListViewPortlet extends CMSPortlet {
     return applicationId;
   }
 
-  private void initNewsListHeaderTranslationSettings(RenderRequest request) {
-    String applicationId = request.getAttribute(APPLICATION_ID).toString();
-    String settingName = request.getAttribute("settingName").toString();
+  private void initNewsListHeaderTranslationSettings(String applicationId, String settingName) {
     SettingValue<?> storedSettingNameValue = getSettingService().get(NewsUtils.NEWS_LIST_VIEW_CONTEXT,
                                                                      NewsUtils.NEWS_LIST_VIEW_SCOPE,
                                                                      applicationId);
@@ -106,5 +125,12 @@ public class NewsListViewPortlet extends CMSPortlet {
       settingService = ExoContainerContext.getService(SettingService.class);
     }
     return settingService;
+  }
+
+  private TranslationService getTranslationService() {
+    if (translationService == null) {
+      translationService = ExoContainerContext.getService(TranslationService.class);
+    }
+    return translationService;
   }
 }


### PR DESCRIPTION
Prior to this change, when creating a new template (page, space, or section) and inserting a News List portlet, changing the portlet header name would update it in all instances. This issue occurred because the translation service used the generated application ID as the object ID to store header translation labels. This change introduces a NewsListPortletInstancePreferencePlugin that initializes preferences for each portlet instance, ensuring that header translations are stored independently and resolving the issue.