### PR TITLE
fix: Fix editing for the first time the latest draft of an article issued from a published note - EXO-87311

### DIFF
--- a/content-service/src/main/java/io/meeds/content/news/service/NewsService.java
+++ b/content-service/src/main/java/io/meeds/content/news/service/NewsService.java
@@ -2530,7 +2530,7 @@ public class NewsService {
       return parentArticle;
     }
     News draftArticle = buildDraftArticle(latestDraft.getId(), currentIdentity);
-
+    draftArticle.setActivityId(parentArticle.getActivityId());   
     draftArticle.setReferred(parentArticle.isReferred());
     draftArticle.setFromExternalPage(parentArticle.isFromExternalPage());
     draftArticle.setOwner(parentArticle.getOwner());


### PR DESCRIPTION
Prior to this change, when a note was published and a draft was subsequently created from it, the first attempt to edit the corresponding article caused the draft save process to remain stuck indefinitely. This issue occurred because the latest article draft was being edited using the draft ID itself instead of the target page ID. As a result, the draft save operation could not complete successfully. The draft editing mechanism relies on the activityId to determine whether to use the draft ID or the target page ID. However, in the specific case of the first edit of an article created from a published note, the activityId was missing. To resolve this issue, we now ensure that the activityId information is available in this scenario, allowing the draft save process to correctly identify the target page and complete successfully.