### PR TITLE
fix: Add missing dependency to news details activity stream extension - EXO-87658 

### DIFF
--- a/content-webapp/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/content-webapp/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -676,7 +676,19 @@
       <module>newsDetails</module>
     </depends>
     <depends>
+      <module>vue</module>
+    </depends>
+    <depends>
+      <module>vuetify</module>
+    </depends>
+    <depends>
       <module>eXoVueI18n</module>
+    </depends>
+    <depends>
+      <module>extensionRegistry</module>
+    </depends>
+    <depends>
+      <module>commonVueComponents</module>
     </depends>
   </module>
 


### PR DESCRIPTION
Prior to this change, a console error was displayed due to a missing dependency in the activity stream details extension. This change adds the missing dependency.