### PR TITLE
feat: migrate statistic fields to typed collection API - EXO-87596

### DIFF
--- a/content-service/src/main/java/io/meeds/content/news/listener/AnalyticsNewsListener.java
+++ b/content-service/src/main/java/io/meeds/content/news/listener/AnalyticsNewsListener.java
@@ -117,17 +117,17 @@ public class AnalyticsNewsListener extends Listener<Object, News> {
     statisticData.setSubModule("contents");
     statisticData.setOperation(operation);
     statisticData.setUserId(userId);
-    statisticData.addParameter("contentId", news.getId());
-    statisticData.addParameter("contentTitle", news.getTitle());
+    statisticData.addKeyword("contentId", news.getId());
+    statisticData.addKeyword("contentTitle", news.getTitle());
     if (operation.equals(VIEW_CONTENT_OPERATION_NAME) || operation.equals(UPDATE_CONTENT_OPERATION_NAME)
         || operation.equals(DELETE_CONTENT_OPERATION_NAME)) {
-      statisticData.addParameter("contentLanguage", news.getLang() != null ? news.getLang() : "originalVersion");
+      statisticData.addKeyword("contentLanguage", news.getLang() != null ? news.getLang() : "originalVersion");
     }
-    statisticData.addParameter("contentCreator", news.getOwner());
-    statisticData.addParameter("contentLastModifier", username);
-    statisticData.addParameter("contentType", "News");
-    statisticData.addParameter("contentUpdatedDate", news.getUpdateDate());
-    statisticData.addParameter("contentCreationDate", news.getCreationDate());
+    statisticData.addKeyword("contentCreator", news.getOwner());
+    statisticData.addKeyword("contentLastModifier", username);
+    statisticData.addKeyword("contentType", "News");
+    statisticData.addDate("contentUpdatedDate", news.getUpdateDate());
+    statisticData.addDate("contentCreationDate", news.getCreationDate());
     Space space = getSpaceService().getSpaceById(news.getSpaceId());
     if (space != null) {
       addSpaceStatistics(statisticData, space);

--- a/content-service/src/main/java/io/meeds/content/news/listener/ContentPublishListener.java
+++ b/content-service/src/main/java/io/meeds/content/news/listener/ContentPublishListener.java
@@ -108,23 +108,25 @@ public class ContentPublishListener extends Listener<String, ContentPublishEvent
     statisticData.setSubModule("contents");
     statisticData.setOperation("publishContent");
     statisticData.setUserId(userId);
-    statisticData.addParameter("contentId", news.getId());
-    statisticData.addParameter("contentTitle", news.getTitle());
-    statisticData.addParameter("contentType", "News");
-    statisticData.addParameter("contentCreator", news.getAuthor());
+    statisticData.addKeyword("contentId", news.getId());
+    statisticData.addKeyword("contentTitle", news.getTitle());
+    statisticData.addKeyword("contentType", "News");
+    statisticData.addKeyword("contentCreator", news.getAuthor());
     List<String> targets = toTargetNames(news);
     if (!targets.isEmpty()) {
-      statisticData.addParameter("contentPublishingTargets", toTargetNames(news));
+      statisticData.addKeyword("contentPublishingTargets", toTargetNames(news));
     }
-    statisticData.addParameter("contentFeedPublishing", news.isActivityPosted() ? "YES" : null);
+    if (news.isActivityPosted()) {
+      statisticData.addKeyword("contentFeedPublishing", "YES");
+    }
     String scheduleDates = toScheduleDates(news);
     if (StringUtils.isNotBlank(scheduleDates)) {
-      statisticData.addParameter("contentScheduling", scheduleDates);
+      statisticData.addDates("contentScheduling", List.of(news.getSchedulePostDate(), news.getScheduleUnpublishDate()));
     }
-    statisticData.addParameter("contentHideAuthor", news.getProperties().isHideAuthor() ? "YES" : "NO");
-    statisticData.addParameter("contentHideReaction", news.getProperties().isHideReaction() ? "YES" : "NO");
-    statisticData.addParameter("contentUpdatedDate",
-                               news.getUpdateDate() != null ? news.getUpdateDate() : news.getCreationDate());
+    statisticData.addKeyword("contentHideAuthor", news.getProperties().isHideAuthor() ? "YES" : "NO");
+    statisticData.addKeyword("contentHideReaction", news.getProperties().isHideReaction() ? "YES" : "NO");
+    statisticData.addDate("contentUpdatedDate",
+                          news.getUpdateDate() != null ? news.getUpdateDate() : news.getCreationDate());
     processSpaceStatistics(statisticData, news);
 
     AnalyticsUtils.addStatisticData(statisticData);


### PR DESCRIPTION
Replace deprecated StatisticData#addParameter usages with explicit typed APIs across product modules.

Use addKeyword/addKeywords for identifiers and labels, addLong for numeric aggregation fields, and typed collection variants where needed. This makes the intended Elasticsearch mapping explicit at producer level and avoids accidental field type changes or unnecessary *_alt mapping creation.