### PR TITLE
fix: Resolve report fields against available mappings - EXO-87755

### DIFF
--- a/content-webapp/src/main/webapp/vue-app/news-extensions/analytics-extensions/components/analytics/AnalyticsTableCellContentValue.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-extensions/analytics-extensions/components/analytics/AnalyticsTableCellContentValue.vue
@@ -49,13 +49,13 @@ export default {
   }),
   computed: {
     contentTitle() {
-      return this.content?.title;
+      return this.content?.title || this.value;
     },
     contentUrl() {
       return this.content?.url;
     },
     isDeleted() {
-      return this.content?.deleted;
+      return this.content?.deleted || (!this.loading && !this.content) || !this.contentUrl;
     }
   },
   created() {


### PR DESCRIPTION
Before this change, when accessing the content report from Analytics, the Title column displayed content IDs instead of content titles. This issue occurred when the title value could not be resolved correctly from the available mappings. To fix this, the display logic was updated to first use the content title when available. If no title can be resolved, the content ID is displayed along with an indication that the content has been deleted. After this change, the Title column correctly displays the content title whenever possible and provides a clear fallback for deleted content.