### PR TITLE
fix: Fix news draft after adding/ deleting images - EXO-87150

### DIFF
--- a/content-webapp/src/main/webapp/vue-app/news-activity-composer-app/components/ContentRichEditor.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-activity-composer-app/components/ContentRichEditor.vue
@@ -653,6 +653,10 @@ export default {
 
       originalImages.each(function(index, element) {
         const originalImageURL = $(element).attr('src');
+        const updatedElement = updatedImages[index];
+        if (!updatedElement) {
+          return;
+        }
         const updatedImageURL = $(updatedImages[index]).attr('src');
         if (updatedImageURL !== originalImageURL) {
           imagesURLs.set(originalImageURL, updatedImageURL);


### PR DESCRIPTION
Prior to this change, deleting an image and then editing the draft body could cause remaining images to lose their correct src. This change will make image URL handling more robust by improving how mappings are tracked and applied, ensuring that images keep their proper source even after deletions or body edits.