### PR TITLE
fix: Fix loading save button when creating or editing contents with content links - EXO-87310

### DIFF
--- a/content-webapp/src/main/webapp/vue-app/news-activity-composer-app/components/ContentRichEditor.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-activity-composer-app/components/ContentRichEditor.vue
@@ -52,6 +52,7 @@
         allowedTargets: allowedTargets
       }"
       :can-redact="canRedact"
+      :is-posting="postingNews"
       :images-download-folder="'DRIVE_ROOT_NODE/News/images'"
       @editor-closed="editorClosed"
       @open-treeview="openTreeView"
@@ -379,11 +380,9 @@ export default {
           alertLinkText: this.$t('news.view.label'),
           alertLink: createdArticle.url
         });
-      }).then(() => {
-        this.draftSavingStatus = '';
-        this.enableClickOnce();
       }).catch((error) => {
         this.displayAlert({type: 'error', message: this.$t('news.save.error.message', error?.message)});
+      }).finally(() => {
         this.enableClickOnce();
         this.draftSavingStatus = '';
       });


### PR DESCRIPTION
Prior to this change, when creating or editing contents containing numerous links, the save operation could take some time to complete without providing any visual indication on the save button.
With this commit, the save button will now display a loading indicator during the save process, giving users clear visibility into the progress and duration of the save operation.