### PR TITLE
feat: Add "Properties" (edit cover + summary) to the News article 3-dots menu - EXO-88359

### DIFF
--- a/content-service/src/main/resources/locale/portlet/news/News_en.properties
+++ b/content-service/src/main/resources/locale/portlet/news/News_en.properties
@@ -165,6 +165,7 @@ news.details.header.menu.share=Share
 news.details.header.menu.edit=Edit
 news.details.header.menu.properties=Properties
 news.details.header.menu.properties.error=Error while updating the article properties
+news.details.header.menu.properties.success=Article properties updated successfully
 news.details.header.menu.copy.link=Copy Link
 news.details.header.menu.exportPdf=Export PDF
 news.details.header.menu.exportPdf.error=Error while exporting the article to PDF

--- a/content-service/src/main/resources/locale/portlet/news/News_en.properties
+++ b/content-service/src/main/resources/locale/portlet/news/News_en.properties
@@ -163,6 +163,8 @@ news.avatar.author.alt={0}'s profile picture
 
 news.details.header.menu.share=Share
 news.details.header.menu.edit=Edit
+news.details.header.menu.properties=Properties
+news.details.header.menu.properties.error=Error while updating the article properties
 news.details.header.menu.copy.link=Copy Link
 news.details.header.menu.exportPdf=Export PDF
 news.details.header.menu.exportPdf.error=Error while exporting the article to PDF

--- a/content-webapp/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/content-webapp/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -371,6 +371,9 @@
       <path>/js/newsDetails.bundle.js</path>
     </script>
     <depends>
+      <module>NotesRichEditor</module>
+    </depends>
+    <depends>
       <module>NotesPublication</module>
     </depends>
     <depends>

--- a/content-webapp/src/main/webapp/vue-app/news-details/components/ExoNewsDetails.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-details/components/ExoNewsDetails.vue
@@ -38,6 +38,7 @@
         @delete-article="deleteConfirmDialog"
         @edit-article="editLink"
         @export-pdf="createPDF"
+        @open-properties="openProperties"
         @open-publication-drawer="openPublicationDrawer" />
       <exo-news-details-body
         ref="newsBody"
@@ -70,7 +71,12 @@
       :news="localNews"
       @edit-article="editLink"
       @export-pdf="createPDF"
+      @open-properties="openProperties"
       @delete-article="deleteConfirmDialog" />
+    <note-editor-metadata-drawer
+      ref="metadataDrawer"
+      :has-featured-image="!!localNews?.illustrationURL"
+      @metadata-updated="saveMetadata" />
     <note-treeview-drawer
       :settings="{
         saveButtonLabel: $t('content.article.refer.label'),
@@ -279,6 +285,20 @@ export default {
       // The capture target (cover + title + body) is owned by the body
       // component, so the export lives there; just delegate to it.
       this.$refs.newsBody?.createPDF();
+    },
+    openProperties() {
+      this.$refs.metadataDrawer.open(this.localNews);
+    },
+    saveMetadata(properties) {
+      if (!properties) {
+        return;
+      }
+      this.$newsServices.updateArticleMetadataProperties(this.localNews.id, properties)
+        .then(() => this.getNewsById(this.localNews?.id || this.newsId))
+        .catch(() => this.displayMessage({
+          message: this.$t('news.details.header.menu.properties.error'),
+          type: 'error'
+        }));
     },
     getArticlePage() {
       return this.$newsServices.getArticlePage(this.localNews?.id || this.newsId).then((page) => {

--- a/content-webapp/src/main/webapp/vue-app/news-details/components/ExoNewsDetails.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-details/components/ExoNewsDetails.vue
@@ -293,8 +293,31 @@ export default {
       if (!properties) {
         return;
       }
-      this.$newsServices.updateArticleMetadataProperties(this.localNews.id, properties)
+      // A published article's id IS its backing note page id; a draft points at targetPageId.
+      // The cover + summary live in that backing note's metadata, so we persist them there,
+      // exactly like the notes "View Properties" flow (NotePage.saveMetadata): send the note
+      // with unchanged title/content so the backend routes into its EDIT_PAGE_PROPERTIES branch,
+      // which writes the featured image + summary honoring lang. The former flat
+      // updateArticleMetadataProperties endpoint expects a Map<String,String> and cannot
+      // deserialize the drawer's nested featuredImage object (HTTP 400), nor does it persist
+      // the cover.
+      const isDraft = !!this.localNews.targetPageId;
+      const pageId = isDraft ? this.localNews.targetPageId : this.localNews.id;
+      properties.noteId = pageId;
+      properties.draft = isDraft;
+      const notePayload = {
+        id: pageId,
+        title: this.localNews.title,
+        content: this.localNews.body,
+        lang: this.localNews.lang,
+        properties
+      };
+      this.$notesService.updateNoteById(notePayload)
         .then(() => this.getNewsById(this.localNews?.id || this.newsId))
+        .then(() => this.displayMessage({
+          message: this.$t('news.details.header.menu.properties.success'),
+          type: 'success'
+        }))
         .catch(() => this.displayMessage({
           message: this.$t('news.details.header.menu.properties.error'),
           type: 'error'

--- a/content-webapp/src/main/webapp/vue-app/news-details/components/ExoNewsDetailsToolBar.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-details/components/ExoNewsDetailsToolBar.vue
@@ -44,7 +44,8 @@
       :show-refer-button="showReferButton"
       @delete-article="$emit('delete-article')"
       @export-pdf="$emit('export-pdf')"
-      @edit-article="$emit('edit-article')" />
+      @edit-article="$emit('edit-article')"
+      @open-properties="$emit('open-properties', $event)" />
     <v-btn
       v-if="publicationState === 'staged'"
       class="btn btn-primary pull-right me-3"

--- a/content-webapp/src/main/webapp/vue-app/news/components/ExoNewsDetailsActionMenuApp.vue
+++ b/content-webapp/src/main/webapp/vue-app/news/components/ExoNewsDetailsActionMenuApp.vue
@@ -47,6 +47,7 @@
       :show-copy-link-button="showCopyLinkButton"
       :show-delete-button="showDeleteButton"
       :show-edit-button="showEditButton"
+      :show-properties-button="showEditButton"
       :current-app="currentApp"
       :show-publish-button="showPublishButton"
       :show-resume-button="showResumeButton"
@@ -55,6 +56,7 @@
       @copy-link="copyLink"
       @export-pdf="$emit('export-pdf')"
       @edit-article="$emit('edit-article', news)"
+      @open-properties="$emit('open-properties', $event)"
       @delete-article="$emit('delete-article')" />
   </v-menu>
 </template>

--- a/content-webapp/src/main/webapp/vue-app/news/components/NewsActionMenuItems.vue
+++ b/content-webapp/src/main/webapp/vue-app/news/components/NewsActionMenuItems.vue
@@ -59,6 +59,19 @@
       </span>
     </v-list-item>
     <v-list-item
+      v-if="showPropertiesButton"
+      class="ps-2 pe-4 action-menu-item d-flex align-center"
+      @click="$emit('open-properties', news)">
+      <v-icon
+        size="16"
+        class="clickable icon-menu">
+        fas fa-info-circle
+      </v-icon>
+      <span class="pt-1 text-color">
+        {{ $t('news.details.header.menu.properties') }}
+      </span>
+    </v-list-item>
+    <v-list-item
       v-if="showShareButton && news.activityId"
       class="ps-2 pe-4 action-menu-item d-flex align-center"
       @click="$root.$emit('activity-share-drawer-open', news.activityId, currentApp)">
@@ -160,6 +173,11 @@ export default {
       default: false
     },
     showEditButton: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
+    showPropertiesButton: {
       type: Boolean,
       required: false,
       default: false

--- a/content-webapp/src/main/webapp/vue-app/news/components/NewsMobileActionMenu.vue
+++ b/content-webapp/src/main/webapp/vue-app/news/components/NewsMobileActionMenu.vue
@@ -29,6 +29,7 @@
         :show-copy-link-button="showCopyLinkButton"
         :show-delete-button="showDeleteButton"
         :show-edit-button="showEditButton"
+        :show-properties-button="showEditButton"
         :current-app="currentApp"
         :show-publish-button="showPublishButton"
         :show-resume-button="showResumeButton"
@@ -37,6 +38,7 @@
         @copy-link="copyLink"
         @export-pdf="exportPdf"
         @edit-article="$emit('edit-article', news)"
+        @open-properties="openProperties"
         @delete-article="$emit('delete-article', news)" />
     </template>
   </exo-drawer>
@@ -88,6 +90,10 @@ export default {
     exportPdf() {
       this.close();
       this.$emit('export-pdf');
+    },
+    openProperties() {
+      this.close();
+      this.$emit('open-properties', this.news);
     },
     copyLink() {
       const portalName = eXo.env.portal.metaPortalName;


### PR DESCRIPTION
## What

Adds a **Properties** item to the News article reader's 3-dots (⋮) menu that opens a drawer to edit the article's **cover (featured image) + summary** in place — parity with the note "View Properties" feature. **Stacked on #808** (Export-PDF); both menu items coexist.

## How

- **Reuses the notes metadata drawer cross-webapp** — `note-editor-metadata-drawer` / `note-metadata-properties-form` are registered by the `NotesRichEditor` gatein module; the `newsDetails` module now `<depends>` on it (`gatein-resources.xml`). No new UI component.
- **Menu item** in `NewsActionMenuItems.vue` (gated on edit rights), event threaded through `ExoNewsDetailsActionMenuApp` → `ExoNewsDetailsToolBar` → `ExoNewsDetails` (+ mobile menu).
- **Persistence** (`ExoNewsDetails.saveMetadata`): writes cover+summary to the **backing note's metadata** via `$notesService.updateNoteById` (`PUT /notes/note/{pageId}`, `EDIT_PAGE_PROPERTIES` branch) — the same proven path notes View Properties uses. Backing page id = `targetPageId ?? news.id`; unchanged title/content route it to the properties-only branch; refetch via `getNewsById` re-renders. i18n keys in `News_en.properties`.

## A note on the persistence path

The first cut called the news-native `updateArticleMetadataProperties` (`PUT /contents/metadata/{id}`) — but that backend takes a flat `Map<String,String>` and doesn't handle the cover, so the nested drawer payload 400'd (found in live testing). Switched to the backing-note metadata path, which handles both cover + summary without re-triggering the activity.

## Verified live (Chrome)

Reader loads with `NotesRichEditor`/CKEditor pulled in (no publicPath/runtime regression) · both "Export PDF" and "Properties" appear · drawer opens pre-filled with the current cover + summary, Notes labels render · **editing the summary + Save 200s and persists** (confirmed on the reloaded news card).

## Known follow-up

Per-language: the drawer edits the currently-viewed language; the same per-language base-properties caveat noted on the MCP tools applies. Front-end only.

Board: EXO-88359.

🤖 Generated with [Claude Code](https://claude.com/claude-code)