### PR TITLE
feat: News publication targets + scheduling MCP tools - EXO-88370

### DIFF
--- a/content-packaging/pom.xml
+++ b/content-packaging/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.meeds.content</groupId>
     <artifactId>content</artifactId>
-    <version>7.3.x-SNAPSHOT</version>
+    <version>7.3.x-ai-contribution-SNAPSHOT</version>
   </parent>
   <artifactId>content-packaging</artifactId>
   <packaging>pom</packaging>

--- a/content-service/pom.xml
+++ b/content-service/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.meeds.content</groupId>
     <artifactId>content</artifactId>
-    <version>7.3.x-SNAPSHOT</version>
+    <version>7.3.x-ai-contribution-SNAPSHOT</version>
   </parent>
   <artifactId>content-service</artifactId>
   <packaging>jar</packaging>

--- a/content-service/src/main/java/io/meeds/content/news/mcp/NewsMcpTool.java
+++ b/content-service/src/main/java/io/meeds/content/news/mcp/NewsMcpTool.java
@@ -225,19 +225,26 @@ public class NewsMcpTool implements McpToolPlugin {
     return toNewsModel(news, space);
   }
 
+  // Updates a news (article) title, body and/or summary. Only the provided
+  // fields are changed. Title/body go through NewsService#updateNews
+  // (CONTENT_AND_TITLE) as before; the summary lives in the note metadata, so it
+  // is persisted the same way as the cover image (NoteService#saveNoteMetadata,
+  // language-aware), based on the loaded properties so the existing featured
+  // image (cover) is preserved. The article is then refreshed (re-index +
+  // recompute) so the new summary lands on the live article.
   @SneakyThrows
   public NewsModel updateNews(long newsId,
                               String title,
                               String summary,
-                              String htmlContent) {
+                              String htmlContent,
+                              String language) {
     checkNewsId(newsId);
     String currentUsername = getCurrentUserName();
     org.exoplatform.services.security.Identity currentIdentity = userAcl.getUserIdentity(currentUsername);
     News news = newsService.getNewsById(String.valueOf(newsId),
                                         currentIdentity,
                                         false,
-                                        NewsObjectType.LATEST_DRAFT.name()
-                                                                   .toLowerCase());
+                                        NewsObjectType.ARTICLE.name().toLowerCase());
     if (news == null) {
       throw new ObjectNotFoundException("""
           News with id '%s' doesn't exist. Use 'search_news' to search for a news bi title, summary or content.
@@ -254,22 +261,44 @@ public class NewsMcpTool implements McpToolPlugin {
           The current user doesn't have priviledges to update the news with id '%s'.
           """.formatted(space.getDisplayName(), space.getSpaceId()));
     }
+    boolean titleOrContentChanged = false;
     if (StringUtils.isNotBlank(title)) {
       news.setTitle(title);
+      titleOrContentChanged = true;
     }
     if (StringUtils.isNotBlank(htmlContent)) {
       news.setBody(markdownToHtml(htmlContent));
+      titleOrContentChanged = true;
     }
+    // Persist title/body first (CONTENT_AND_TITLE ignores metadata, so it never
+    // touches the summary).
+    if (titleOrContentChanged) {
+      newsService.updateNews(news,
+                             currentIdentity.getUserId(),
+                             false,
+                             news.isPublished(),
+                             NewsObjectType.ARTICLE.name().toLowerCase(),
+                             NewsUpdateType.CONTENT_AND_TITLE.name());
+    }
+    // The summary is stored in the note metadata, which NewsUpdateType.* never
+    // writes; persist it the same way the cover image is persisted, basing the
+    // write on the loaded properties so the current featured image is preserved.
     if (StringUtils.isNotBlank(summary)) {
-      news.getProperties().setSummary(summary);
+      NotePageProperties properties = news.getProperties() != null ? news.getProperties() : new NotePageProperties();
+      properties.setSummary(summary);
+      // for a published article news_id == the note page id; a draft/staged
+      // article points at its target page id
+      long pageId = news.getTargetPageId() != null ? Long.parseLong(news.getTargetPageId()) : newsId;
+      boolean isDraft = news.getTargetPageId() != null;
+      properties.setNoteId(pageId);
+      properties.setDraft(isDraft);
+      String lang = StringUtils.isBlank(language) ? news.getLang() : language;
+      noteService.saveNoteMetadata(properties, lang, getUserIdentityId(currentUsername));
     }
-    News updatedNews = newsService.updateNews(news,
-                                              currentIdentity.getUserId(),
-                                              false,
-                                              news.isPublished(),
-                                              NewsObjectType.LATEST_DRAFT.name().toLowerCase(),
-                                              NewsUpdateType.CONTENT_AND_TITLE.name());
-    return toNewsModel(updatedNews, space);
+    // Refresh the news lifecycle (re-index + recompute) so the metadata summary
+    // lands on the live article; CONTENT_AND_TITLE ignores metadata, so the
+    // just-saved summary is not reverted.
+    return refreshAndModel(newsId, currentIdentity, space);
   }
 
   @SneakyThrows

--- a/content-service/src/main/java/io/meeds/content/news/mcp/NewsMcpTool.java
+++ b/content-service/src/main/java/io/meeds/content/news/mcp/NewsMcpTool.java
@@ -29,16 +29,20 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 
 import org.exoplatform.commons.exception.ObjectNotFoundException;
+import org.exoplatform.commons.file.services.FileService;
 import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.container.PortalContainer;
 import org.exoplatform.portal.config.UserACL;
 import org.exoplatform.portal.config.UserPortalConfigService;
+import org.exoplatform.social.attachment.AttachmentService;
 import org.exoplatform.social.core.manager.ActivityManager;
 import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.social.core.processor.I18NActivityProcessor;
 import org.exoplatform.social.core.profileproperty.ProfilePropertyService;
 import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceService;
+import org.exoplatform.upload.UploadService;
+import org.exoplatform.wiki.service.NoteService;
 
 import io.meeds.content.news.mcp.model.NewsModel;
 import io.meeds.content.news.model.News;
@@ -53,7 +57,9 @@ import io.meeds.mcp.server.tool.model.SpaceModel;
 import io.meeds.mcp.server.tool.model.UserModel;
 import io.meeds.mcp.server.tool.util.ActivityToolUtils;
 import io.meeds.mcp.server.tool.util.SpaceToolUtils;
+import io.meeds.mcp.server.tool.util.UploadToolUtils;
 import io.meeds.mcp.server.tool.util.UserToolUtils;
+import io.meeds.notes.model.NoteFeaturedImage;
 import io.meeds.notes.model.NotePageProperties;
 import io.meeds.portal.permlink.service.PermanentLinkService;
 import io.meeds.social.translation.service.TranslationService;
@@ -86,6 +92,14 @@ public class NewsMcpTool implements McpToolPlugin {
 
   private UserPortalConfigService portalConfigService;
 
+  private NoteService             noteService;
+
+  private UploadService           uploadService;
+
+  private AttachmentService       attachmentService;
+
+  private FileService             fileService;
+
   public NewsMcpTool(PortalContainer container) {
     this.spaceService = container.getComponentInstanceOfType(SpaceService.class);
     this.activityManager = container.getComponentInstanceOfType(ActivityManager.class);
@@ -97,6 +111,10 @@ public class NewsMcpTool implements McpToolPlugin {
     this.profilePropertyService = container.getComponentInstanceOfType(ProfilePropertyService.class);
     this.translationService = container.getComponentInstanceOfType(TranslationService.class);
     this.portalConfigService = container.getComponentInstanceOfType(UserPortalConfigService.class);
+    this.noteService = container.getComponentInstanceOfType(NoteService.class);
+    this.uploadService = container.getComponentInstanceOfType(UploadService.class);
+    this.attachmentService = container.getComponentInstanceOfType(AttachmentService.class);
+    this.fileService = container.getComponentInstanceOfType(FileService.class);
   }
 
   @SneakyThrows
@@ -348,6 +366,147 @@ public class NewsMcpTool implements McpToolPlugin {
     return toNewsModel(news, space);
   }
 
+  // Sets a news (article) cover / illustration from exactly one of a public
+  // http(s) URL, base64 bytes, or an ACL-checked reference to an existing
+  // platform attachment. The cover is shared with the backing note's featured
+  // image, so it is written onto the article note's metadata and then the news
+  // lifecycle is refreshed (search re-index + linked activity thumbnail).
+  @SneakyThrows
+  public NewsModel setNewsIllustration(long newsId,
+                                       String imageUrl,
+                                       String imageBase64,
+                                       String attachmentObjectType,
+                                       String attachmentObjectId,
+                                       String altText,
+                                       String language) {
+    checkNewsId(newsId);
+    String currentUsername = getCurrentUserName();
+    org.exoplatform.services.security.Identity currentIdentity = userAcl.getUserIdentity(currentUsername);
+    News news = newsService.getNewsById(String.valueOf(newsId),
+                                        currentIdentity,
+                                        false,
+                                        NewsObjectType.ARTICLE.name().toLowerCase());
+    if (news == null) {
+      throw new ObjectNotFoundException("""
+          News with id '%s' wasn't found.
+          Use 'search_news' Tool to find News details by a search term.
+          """.formatted(newsId));
+    }
+    Space space = spaceService.getSpaceById(news.getSpaceId());
+    if (space == null) {
+      throw new ObjectNotFoundException("""
+          News with id '%s' doesn't have an associated space.
+          """.formatted(newsId));
+    }
+    if (!newsService.canEditNews(news, currentUsername)) {
+      throw new IllegalAccessException("""
+          The current user doesn't have priviledges to update the news with id '%s'.
+          """.formatted(newsId));
+    }
+    UploadToolUtils.FetchedImage image = UploadToolUtils.resolveImage(attachmentService,
+                                                                      fileService,
+                                                                      getCurrentUserAclIdentity(),
+                                                                      imageUrl,
+                                                                      imageBase64,
+                                                                      attachmentObjectType,
+                                                                      attachmentObjectId,
+                                                                      UploadToolUtils.DEFAULT_MAX_BYTES);
+    String uploadId = UploadToolUtils.materialize(uploadService, image.bytes(), image.fileName(), image.mimeType());
+    // for a published article news_id == the note page id; a draft/staged article
+    // points at its target page id
+    long pageId = news.getTargetPageId() != null ? Long.parseLong(news.getTargetPageId()) : newsId;
+    boolean isDraft = news.getTargetPageId() != null;
+    try {
+      NotePageProperties properties = news.getProperties() != null ? news.getProperties() : new NotePageProperties();
+      NoteFeaturedImage featuredImage = new NoteFeaturedImage();
+      NoteFeaturedImage existing = properties.getFeaturedImage();
+      if (existing != null && existing.getId() != null && existing.getId() > 0) {
+        featuredImage.setId(existing.getId()); // update the existing cover file in place
+      }
+      featuredImage.setUploadId(uploadId);
+      featuredImage.setMimeType(image.mimeType());
+      featuredImage.setFileName(image.fileName());
+      featuredImage.setAltText(altText);
+      properties.setNoteId(pageId);
+      properties.setDraft(isDraft);
+      properties.setFeaturedImage(featuredImage);
+      String lang = StringUtils.isBlank(language) ? news.getLang() : language;
+      noteService.saveNoteMetadata(properties, lang, getUserIdentityId(currentUsername));
+    } catch (Exception e) {
+      UploadToolUtils.release(uploadService, uploadId);
+      throw new IllegalStateException("Could not set the news cover image: " + e.getMessage());
+    }
+    return refreshAndModel(newsId, currentIdentity, space);
+  }
+
+  // Removes a news (article) cover / illustration. Mirrors the note featured
+  // image removal, then refreshes the news lifecycle.
+  @SneakyThrows
+  public NewsModel removeNewsIllustration(long newsId, String language) {
+    checkNewsId(newsId);
+    String currentUsername = getCurrentUserName();
+    org.exoplatform.services.security.Identity currentIdentity = userAcl.getUserIdentity(currentUsername);
+    News news = newsService.getNewsById(String.valueOf(newsId),
+                                        currentIdentity,
+                                        false,
+                                        NewsObjectType.ARTICLE.name().toLowerCase());
+    if (news == null) {
+      throw new ObjectNotFoundException("""
+          News with id '%s' wasn't found.
+          Use 'search_news' Tool to find News details by a search term.
+          """.formatted(newsId));
+    }
+    Space space = spaceService.getSpaceById(news.getSpaceId());
+    if (space == null) {
+      throw new ObjectNotFoundException("""
+          News with id '%s' doesn't have an associated space.
+          """.formatted(newsId));
+    }
+    if (!newsService.canEditNews(news, currentUsername)) {
+      throw new IllegalAccessException("""
+          The current user doesn't have priviledges to update the news with id '%s'.
+          """.formatted(newsId));
+    }
+    NotePageProperties properties = news.getProperties();
+    NoteFeaturedImage existing = properties == null ? null : properties.getFeaturedImage();
+    if (existing == null || existing.getId() == null || existing.getId() <= 0) {
+      throw new ObjectNotFoundException("News with id '%s' has no cover image to remove.".formatted(newsId));
+    }
+    long pageId = news.getTargetPageId() != null ? Long.parseLong(news.getTargetPageId()) : newsId;
+    boolean isDraft = news.getTargetPageId() != null;
+    try {
+      String lang = StringUtils.isBlank(language) ? news.getLang() : language;
+      noteService.removeNoteFeaturedImage(pageId, existing.getId(), lang, isDraft, getUserIdentityId(currentUsername));
+    } catch (Exception e) {
+      throw new IllegalStateException("Could not remove the news cover image: " + e.getMessage());
+    }
+    return refreshAndModel(newsId, currentIdentity, space);
+  }
+
+  // Refreshes the news lifecycle after a cover metadata change (re-index +
+  // linked activity thumbnail + illustrationURL recompute) by going through the
+  // same NewsService#updateNews path the native editor uses, then returns the
+  // up-to-date model.
+  private NewsModel refreshAndModel(long newsId,
+                                    org.exoplatform.services.security.Identity currentIdentity,
+                                    Space space) throws Exception {
+    News refreshed = newsService.getNewsById(String.valueOf(newsId),
+                                             currentIdentity,
+                                             false,
+                                             NewsObjectType.ARTICLE.name().toLowerCase());
+    News updated = newsService.updateNews(refreshed,
+                                          currentIdentity.getUserId(),
+                                          false,
+                                          refreshed.isPublished(),
+                                          NewsObjectType.ARTICLE.name().toLowerCase(),
+                                          NewsUpdateType.CONTENT_AND_TITLE.name());
+    return toNewsModel(updated, space);
+  }
+
+  private long getUserIdentityId(String username) {
+    return Long.parseLong(identityManager.getOrCreateUserIdentity(username).getId());
+  }
+
   private void checkNewsId(long newsId) {
     if (newsId <= 0) {
       throw new IllegalArgumentException("""
@@ -394,7 +553,8 @@ public class NewsMcpTool implements McpToolPlugin {
                          news.isActivityPosted(),
                          getActivityId(news),
                          publisherUser,
-                         targetSpace);
+                         targetSpace,
+                         news.getIllustrationURL());
   }
 
   private long getActivityId(News news) {

--- a/content-service/src/main/java/io/meeds/content/news/mcp/model/NewsModel.java
+++ b/content-service/src/main/java/io/meeds/content/news/mcp/model/NewsModel.java
@@ -55,5 +55,7 @@ public record NewsModel(
                         long activityId,
                         UserModel publisher,
                         @JsonProperty("target_space")
-                        SpaceModel targetSpace) {
+                        SpaceModel targetSpace,
+                        @JsonProperty("illustration_url")
+                        String illustrationUrl) {
 }

--- a/content-service/src/main/resources/ai-tool-definitions.json
+++ b/content-service/src/main/resources/ai-tool-definitions.json
@@ -118,6 +118,73 @@
         "idempotentHint": true,
         "openWorldHint": false
       }
+    },
+    {
+      "name": "update_news",
+      "title": "Update an article",
+      "description": "Update the title, summary and/or HTML content of an existing news (Article). Only the provided fields are changed.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "news_id": { "type": "integer" },
+          "title": { "type": "string" },
+          "summary": { "type": "string" },
+          "html_content": { "type": "string" }
+        },
+        "required": ["news_id"]
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "require_approval": true
+    },
+    {
+      "name": "set_news_illustration",
+      "title": "Set an article cover image",
+      "description": "Set the cover (illustration) image of a news (Article) from exactly one of: a public image URL, a base64-encoded image, or a reference to a file already attached to a platform object (attachment_object_type + attachment_object_id).",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "news_id": { "type": "integer" },
+          "image_url": { "type": "string" },
+          "image_base64": { "type": "string" },
+          "attachment_object_type": { "type": "string" },
+          "attachment_object_id": { "type": "string" },
+          "alt_text": { "type": "string" },
+          "language": { "type": "string" }
+        },
+        "required": ["news_id"]
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "require_approval": true
+    },
+    {
+      "name": "remove_news_illustration",
+      "title": "Remove an article cover image",
+      "description": "Remove the cover (illustration) image of a news (Article).",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "news_id": { "type": "integer" },
+          "language": { "type": "string" }
+        },
+        "required": ["news_id"]
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "require_approval": true
     }
   ]
 }

--- a/content-service/src/main/resources/ai-tool-definitions.json
+++ b/content-service/src/main/resources/ai-tool-definitions.json
@@ -122,14 +122,15 @@
     {
       "name": "update_news",
       "title": "Update an article",
-      "description": "Update the title, summary and/or HTML content of an existing news (Article). Only the provided fields are changed.",
+      "description": "Update the title, summary and/or HTML content of an existing news (Article). Only the provided fields are changed. The optional 'language' targets the summary translation to update (defaults to the article's default language).",
       "input_schema": {
         "type": "object",
         "properties": {
           "news_id": { "type": "integer" },
           "title": { "type": "string" },
           "summary": { "type": "string" },
-          "html_content": { "type": "string" }
+          "html_content": { "type": "string" },
+          "language": { "type": "string" }
         },
         "required": ["news_id"]
       },

--- a/content-service/src/test/java/io/meeds/content/news/mcp/NewsMcpToolTest.java
+++ b/content-service/src/test/java/io/meeds/content/news/mcp/NewsMcpToolTest.java
@@ -21,6 +21,7 @@ package io.meeds.content.news.mcp;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
@@ -43,18 +44,22 @@ import org.mockito.MockedStatic;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import org.exoplatform.commons.exception.ObjectNotFoundException;
+import org.exoplatform.commons.file.services.FileService;
 import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.container.PortalContainer;
 import org.exoplatform.portal.config.UserACL;
 import org.exoplatform.portal.config.UserPortalConfigService;
 import org.exoplatform.portal.config.model.PortalConfig;
 import org.exoplatform.services.security.Identity;
+import org.exoplatform.social.attachment.AttachmentService;
 import org.exoplatform.social.core.manager.ActivityManager;
 import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.social.core.processor.I18NActivityProcessor;
 import org.exoplatform.social.core.profileproperty.ProfilePropertyService;
 import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceService;
+import org.exoplatform.upload.UploadService;
+import org.exoplatform.wiki.service.NoteService;
 
 import io.meeds.content.news.mcp.model.NewsModel;
 import io.meeds.content.news.model.News;
@@ -64,8 +69,10 @@ import io.meeds.content.news.utils.NewsUtils.NewsObjectType;
 import io.meeds.mcp.server.tool.model.SpaceModel;
 import io.meeds.mcp.server.tool.model.UserModel;
 import io.meeds.mcp.server.tool.util.SpaceToolUtils;
+import io.meeds.mcp.server.tool.util.UploadToolUtils;
 import io.meeds.mcp.server.tool.util.UserToolUtils;
 import io.meeds.mcp.server.util.McpToolUtils;
+import io.meeds.notes.model.NoteFeaturedImage;
 import io.meeds.notes.model.NotePageProperties;
 import io.meeds.portal.permlink.service.PermanentLinkService;
 import io.meeds.social.translation.service.TranslationService;
@@ -119,6 +126,18 @@ public class NewsMcpToolTest {
   private UserPortalConfigService portalConfigService;
 
   @Mock
+  private NoteService             noteService;
+
+  @Mock
+  private UploadService           uploadService;
+
+  @Mock
+  private AttachmentService       attachmentService;
+
+  @Mock
+  private FileService             fileService;
+
+  @Mock
   private Identity                currentIdentity;
 
   private NewsMcpTool             tool;
@@ -135,6 +154,10 @@ public class NewsMcpToolTest {
     when(container.getComponentInstanceOfType(ProfilePropertyService.class)).thenReturn(profilePropertyService);
     when(container.getComponentInstanceOfType(TranslationService.class)).thenReturn(translationService);
     when(container.getComponentInstanceOfType(UserPortalConfigService.class)).thenReturn(portalConfigService);
+    when(container.getComponentInstanceOfType(NoteService.class)).thenReturn(noteService);
+    when(container.getComponentInstanceOfType(UploadService.class)).thenReturn(uploadService);
+    when(container.getComponentInstanceOfType(AttachmentService.class)).thenReturn(attachmentService);
+    when(container.getComponentInstanceOfType(FileService.class)).thenReturn(fileService);
 
     lenient().when(currentIdentity.getUserId()).thenReturn(USER);
     lenient().when(userAcl.getUserIdentity(USER)).thenReturn(currentIdentity);
@@ -380,6 +403,119 @@ public class NewsMcpToolTest {
     verify(newsService).postNews(article, USER);
   }
 
+  @Test
+  public void updateNewsShouldSetSummaryOnProperties() throws Exception { // NOSONAR
+    News news = mockNews();
+    Space space = mockSpace();
+    NotePageProperties properties = news.getProperties();
+
+    when(newsService.getNewsById(eq(String.valueOf(NEWS_ID)), eq(currentIdentity), eq(false), anyString()))
+                                                                                                           .thenReturn(news);
+    when(spaceService.getSpaceById(String.valueOf(SPACE_ID))).thenReturn(space);
+    when(newsService.canEditNews(news, USER)).thenReturn(true);
+    when(newsService.updateNews(eq(news), eq(USER), eq(false), anyBoolean(), anyString(), anyString()))
+                                                                                                       .thenReturn(news);
+
+    runWithStaticMocks(() -> tool.updateNews(NEWS_ID, null, "New summary", null));
+
+    assertEquals("New summary", properties.getSummary());
+  }
+
+  @Test
+  public void getNewsByIdShouldExposeIllustrationUrl() throws Exception { // NOSONAR
+    News news = mockNews();
+    Space space = mockSpace();
+
+    when(newsService.getNewsById(eq(String.valueOf(NEWS_ID)), eq(currentIdentity), eq(false), anyString()))
+                                                                                                           .thenReturn(news);
+    when(newsService.canViewNews(news, USER)).thenReturn(true);
+    when(spaceService.getSpaceById(String.valueOf(SPACE_ID))).thenReturn(space);
+
+    NewsModel result = runWithStaticMocks(() -> tool.getNewsById(NEWS_ID));
+
+    assertEquals("/portal/rest/notes/illustration/" + NEWS_ID, result.illustrationUrl());
+  }
+
+  @Test(expected = IllegalAccessException.class)
+  public void setNewsIllustrationWhenUserCannotEditShouldThrowException() throws Exception { // NOSONAR
+    News news = mockNews();
+    Space space = mockSpace();
+
+    when(newsService.getNewsById(eq(String.valueOf(NEWS_ID)), eq(currentIdentity), eq(false), anyString()))
+                                                                                                           .thenReturn(news);
+    when(spaceService.getSpaceById(String.valueOf(SPACE_ID))).thenReturn(space);
+    when(newsService.canEditNews(news, USER)).thenReturn(false);
+
+    tool.setNewsIllustration(NEWS_ID, "https://meeds.test/cover.png", null, null, null, "alt", "en");
+  }
+
+  @Test
+  public void setNewsIllustrationShouldSaveMetadataAndRefresh() throws Exception { // NOSONAR
+    News news = mockNews();
+    Space space = mockSpace();
+    mockUserIdentity();
+
+    when(newsService.getNewsById(eq(String.valueOf(NEWS_ID)), eq(currentIdentity), eq(false), anyString()))
+                                                                                                           .thenReturn(news);
+    when(spaceService.getSpaceById(String.valueOf(SPACE_ID))).thenReturn(space);
+    when(newsService.canEditNews(news, USER)).thenReturn(true);
+    when(newsService.updateNews(eq(news), eq(USER), eq(false), anyBoolean(), anyString(), anyString()))
+                                                                                                       .thenReturn(news);
+
+    NewsModel result = runWithUploadMocks(() -> tool.setNewsIllustration(NEWS_ID,
+                                                                         "https://meeds.test/cover.png",
+                                                                         null,
+                                                                         null,
+                                                                         null,
+                                                                         "alt",
+                                                                         "en"));
+
+    assertEquals(NEWS_ID, result.id());
+    verify(noteService).saveNoteMetadata(any(NotePageProperties.class), eq("en"), eq(1L));
+    verify(newsService).updateNews(eq(news), eq(USER), eq(false), anyBoolean(), anyString(), anyString());
+  }
+
+  @Test(expected = ObjectNotFoundException.class)
+  public void removeNewsIllustrationWhenNoCoverShouldThrowException() throws Exception { // NOSONAR
+    News news = mockNews();
+    Space space = mockSpace();
+
+    when(newsService.getNewsById(eq(String.valueOf(NEWS_ID)), eq(currentIdentity), eq(false), anyString()))
+                                                                                                           .thenReturn(news);
+    when(spaceService.getSpaceById(String.valueOf(SPACE_ID))).thenReturn(space);
+    when(newsService.canEditNews(news, USER)).thenReturn(true);
+
+    tool.removeNewsIllustration(NEWS_ID, "en");
+  }
+
+  @Test
+  public void removeNewsIllustrationShouldRemoveFeaturedImageAndRefresh() throws Exception { // NOSONAR
+    News news = mockNews();
+    news.getProperties().setFeaturedImage(new NoteFeaturedImage(500L, null, null, 0L, 0L, null, null));
+    Space space = mockSpace();
+    mockUserIdentity();
+
+    when(newsService.getNewsById(eq(String.valueOf(NEWS_ID)), eq(currentIdentity), eq(false), anyString()))
+                                                                                                           .thenReturn(news);
+    when(spaceService.getSpaceById(String.valueOf(SPACE_ID))).thenReturn(space);
+    when(newsService.canEditNews(news, USER)).thenReturn(true);
+    when(newsService.updateNews(eq(news), eq(USER), eq(false), anyBoolean(), anyString(), anyString()))
+                                                                                                       .thenReturn(news);
+
+    NewsModel result = runWithStaticMocks(() -> tool.removeNewsIllustration(NEWS_ID, "en"));
+
+    assertEquals(NEWS_ID, result.id());
+    verify(noteService).removeNoteFeaturedImage(eq(NEWS_ID), eq(500L), eq("en"), eq(false), eq(1L));
+    verify(newsService).updateNews(eq(news), eq(USER), eq(false), anyBoolean(), anyString(), anyString());
+  }
+
+  private void mockUserIdentity() {
+    org.exoplatform.social.core.identity.model.Identity socialIdentity =
+                                                                       mock(org.exoplatform.social.core.identity.model.Identity.class);
+    lenient().when(socialIdentity.getId()).thenReturn("1");
+    when(identityManager.getOrCreateUserIdentity(USER)).thenReturn(socialIdentity);
+  }
+
   private News mockNews() {
     return mockNews(String.valueOf(NEWS_ID), SPACE_ID, TITLE);
   }
@@ -403,6 +539,7 @@ public class NewsMcpToolTest {
     lenient().when(news.getViewsCount()).thenReturn(3L);
     lenient().when(news.getCommentsCount()).thenReturn(1);
     lenient().when(news.getLikesCount()).thenReturn(2);
+    lenient().when(news.getIllustrationURL()).thenReturn("/portal/rest/notes/illustration/" + id);
     return news;
   }
 
@@ -457,6 +594,23 @@ public class NewsMcpToolTest {
             .thenReturn(spaceModel);
 
       return supplier.get();
+    }
+  }
+
+  private <T> T runWithUploadMocks(CheckedSupplier<T> supplier) throws Exception { // NOSONAR
+    try (MockedStatic<UploadToolUtils> upload = mockStatic(UploadToolUtils.class)) {
+      UploadToolUtils.FetchedImage image = new UploadToolUtils.FetchedImage(new byte[] { 1, 2, 3 }, "image/png", "image.png");
+      upload.when(() -> UploadToolUtils.resolveImage(any(),
+                                                     any(),
+                                                     any(),
+                                                     any(),
+                                                     any(),
+                                                     any(),
+                                                     any(),
+                                                     anyLong()))
+            .thenReturn(image);
+      upload.when(() -> UploadToolUtils.materialize(any(), any(), anyString(), anyString())).thenReturn("upload-1");
+      return runWithStaticMocks(supplier);
     }
   }
 

--- a/content-service/src/test/java/io/meeds/content/news/mcp/NewsMcpToolTest.java
+++ b/content-service/src/test/java/io/meeds/content/news/mcp/NewsMcpToolTest.java
@@ -24,6 +24,7 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
@@ -220,7 +221,7 @@ public class NewsMcpToolTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void updateNewsWhenNewsIdInvalidShouldThrowException() throws Exception { // NOSONAR
-    tool.updateNews(0, TITLE, SUMMARY, CONTENT);
+    tool.updateNews(0, TITLE, SUMMARY, CONTENT, "en");
   }
 
   @Test(expected = ObjectNotFoundException.class)
@@ -228,10 +229,10 @@ public class NewsMcpToolTest {
     when(newsService.getNewsById(eq(String.valueOf(NEWS_ID)),
                                  eq(currentIdentity),
                                  eq(false),
-                                 eq(NewsObjectType.LATEST_DRAFT.name().toLowerCase())))
-                                                                                       .thenReturn(null);
+                                 eq(NewsObjectType.ARTICLE.name().toLowerCase())))
+                                                                                  .thenReturn(null);
 
-    tool.updateNews(NEWS_ID, TITLE, SUMMARY, CONTENT);
+    tool.updateNews(NEWS_ID, TITLE, SUMMARY, CONTENT, "en");
   }
 
   @Test(expected = IllegalAccessException.class)
@@ -244,13 +245,14 @@ public class NewsMcpToolTest {
     when(spaceService.getSpaceById(String.valueOf(SPACE_ID))).thenReturn(space);
     when(newsService.canEditNews(news, USER)).thenReturn(false);
 
-    tool.updateNews(NEWS_ID, TITLE, SUMMARY, CONTENT);
+    tool.updateNews(NEWS_ID, TITLE, SUMMARY, CONTENT, "en");
   }
 
   @Test
   public void updateNewsShouldUpdateTitleSummaryAndContent() throws Exception { // NOSONAR
     News news = mockNews();
     Space space = mockSpace();
+    mockUserIdentity();
 
     when(newsService.getNewsById(eq(String.valueOf(NEWS_ID)), eq(currentIdentity), eq(false), anyString()))
                                                                                                            .thenReturn(news);
@@ -259,12 +261,16 @@ public class NewsMcpToolTest {
     when(newsService.updateNews(eq(news), eq(USER), eq(false), anyBoolean(), anyString(), anyString()))
                                                                                                        .thenReturn(news);
 
-    NewsModel result = runWithStaticMocks(() -> tool.updateNews(NEWS_ID, "Updated", "Updated summary", "Updated content"));
+    NewsModel result = runWithStaticMocks(() -> tool.updateNews(NEWS_ID, "Updated", "Updated summary", "Updated content", "en"));
 
     assertEquals(NEWS_ID, result.id());
     verify(news).setTitle("Updated");
     verify(news).setBody("<p>Updated content</p>");
-    verify(newsService).updateNews(eq(news), eq(USER), eq(false), anyBoolean(), anyString(), anyString());
+    // title/body persisted via CONTENT_AND_TITLE, then the article is refreshed
+    verify(newsService, atLeastOnce()).updateNews(eq(news), eq(USER), eq(false), anyBoolean(), anyString(), anyString());
+    // summary persisted as note metadata (not via CONTENT_AND_TITLE)
+    verify(noteService).saveNoteMetadata(any(NotePageProperties.class), eq("en"), eq(1L));
+    assertEquals("Updated summary", news.getProperties().getSummary());
   }
 
   @Test(expected = ObjectNotFoundException.class)
@@ -407,6 +413,7 @@ public class NewsMcpToolTest {
   public void updateNewsShouldSetSummaryOnProperties() throws Exception { // NOSONAR
     News news = mockNews();
     Space space = mockSpace();
+    mockUserIdentity();
     NotePageProperties properties = news.getProperties();
 
     when(newsService.getNewsById(eq(String.valueOf(NEWS_ID)), eq(currentIdentity), eq(false), anyString()))
@@ -416,9 +423,54 @@ public class NewsMcpToolTest {
     when(newsService.updateNews(eq(news), eq(USER), eq(false), anyBoolean(), anyString(), anyString()))
                                                                                                        .thenReturn(news);
 
-    runWithStaticMocks(() -> tool.updateNews(NEWS_ID, null, "New summary", null));
+    runWithStaticMocks(() -> tool.updateNews(NEWS_ID, null, "New summary", null, "en"));
 
     assertEquals("New summary", properties.getSummary());
+    // summary persisted via the metadata-aware path, not CONTENT_AND_TITLE
+    verify(noteService).saveNoteMetadata(eq(properties), eq("en"), eq(1L));
+  }
+
+  @Test
+  public void updateNewsShouldPreserveFeaturedImageWhenUpdatingSummary() throws Exception { // NOSONAR
+    News news = mockNews();
+    Space space = mockSpace();
+    mockUserIdentity();
+    NotePageProperties properties = news.getProperties();
+    NoteFeaturedImage cover = new NoteFeaturedImage(500L, null, null, 0L, 0L, null, null);
+    properties.setFeaturedImage(cover);
+
+    when(newsService.getNewsById(eq(String.valueOf(NEWS_ID)), eq(currentIdentity), eq(false), anyString()))
+                                                                                                           .thenReturn(news);
+    when(spaceService.getSpaceById(String.valueOf(SPACE_ID))).thenReturn(space);
+    when(newsService.canEditNews(news, USER)).thenReturn(true);
+    when(newsService.updateNews(eq(news), eq(USER), eq(false), anyBoolean(), anyString(), anyString()))
+                                                                                                       .thenReturn(news);
+
+    runWithStaticMocks(() -> tool.updateNews(NEWS_ID, null, "New summary", null, "en"));
+
+    // the cover image is not wiped when only the summary is updated
+    assertEquals(cover, properties.getFeaturedImage());
+    verify(noteService).saveNoteMetadata(eq(properties), eq("en"), eq(1L));
+  }
+
+  @Test
+  public void updateNewsShouldUseArticleLanguageWhenLanguageBlank() throws Exception { // NOSONAR
+    News news = mockNews();
+    Space space = mockSpace();
+    mockUserIdentity();
+    lenient().when(news.getLang()).thenReturn("fr");
+
+    when(newsService.getNewsById(eq(String.valueOf(NEWS_ID)), eq(currentIdentity), eq(false), anyString()))
+                                                                                                           .thenReturn(news);
+    when(spaceService.getSpaceById(String.valueOf(SPACE_ID))).thenReturn(space);
+    when(newsService.canEditNews(news, USER)).thenReturn(true);
+    when(newsService.updateNews(eq(news), eq(USER), eq(false), anyBoolean(), anyString(), anyString()))
+                                                                                                       .thenReturn(news);
+
+    runWithStaticMocks(() -> tool.updateNews(NEWS_ID, null, "New summary", null, null));
+
+    // blank language falls back to the article's default language
+    verify(noteService).saveNoteMetadata(any(NotePageProperties.class), eq("fr"), eq(1L));
   }
 
   @Test

--- a/content-webapp/pom.xml
+++ b/content-webapp/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.meeds.content</groupId>
     <artifactId>content</artifactId>
-    <version>7.3.x-SNAPSHOT</version>
+    <version>7.3.x-ai-contribution-SNAPSHOT</version>
   </parent>
   <artifactId>content-webapp</artifactId>
   <packaging>war</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,11 @@
   <properties>
     <addon.meeds.notes.version>7.3.x-ai-contribution-SNAPSHOT</addon.meeds.notes.version>
     <addon.meeds.layout.version>7.3.x-ai-contribution-SNAPSHOT</addon.meeds.layout.version>
-    <addon.meeds.mcp-server.version>7.3.x-SNAPSHOT</addon.meeds.mcp-server.version>
+    <!-- News cover MCP tools (set/remove illustration) use UploadToolUtils.resolveImage,
+         added in mcp-server PR #13 (branch feat/mcp-media-tools). Until #13 merges to
+         mcp-server's develop, this consumes the locally-installed ai-contribution SNAPSHOT.
+         Revert to 7.3.x-SNAPSHOT once #13 is released. -->
+    <addon.meeds.mcp-server.version>7.3.x-ai-contribution-SNAPSHOT</addon.meeds.mcp-server.version>
 
     <!-- Sonar properties -->
     <sonar.organization>meeds-io</sonar.organization>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   </parent>
   <groupId>io.meeds.content</groupId>
   <artifactId>content</artifactId>
-  <version>7.3.x-SNAPSHOT</version>
+  <version>7.3.x-ai-contribution-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Meeds - Content Addon - Parent POM</name>
   <description>Content</description>
@@ -38,8 +38,8 @@
   </modules>
 
   <properties>
-    <addon.meeds.notes.version>7.3.x-SNAPSHOT</addon.meeds.notes.version>
-    <addon.meeds.layout.version>7.3.x-SNAPSHOT</addon.meeds.layout.version>
+    <addon.meeds.notes.version>7.3.x-ai-contribution-SNAPSHOT</addon.meeds.notes.version>
+    <addon.meeds.layout.version>7.3.x-ai-contribution-SNAPSHOT</addon.meeds.layout.version>
     <addon.meeds.mcp-server.version>7.3.x-SNAPSHOT</addon.meeds.mcp-server.version>
 
     <!-- Sonar properties -->


### PR DESCRIPTION
## What

Adds 4 News publication/lifecycle MCP tools to `NewsMcpTool`, completing the Communications-Agent loop (route to slider/sections, schedule, unpublish). **Stacked on #807.** EVA acts as the user; ACLs enforced.

## Tools
- **`list_news_targets()`** (read) — instance publication targets with a per-user `can_publish` hint (`NewsTargetingService.getAllTargets()` + `getAllowedTargets(identity)`). Returns `NewsTargetModel{name, label, can_publish}`.
- **`publish_news(news_id, targets[])`** (write) — with targets → `NewsTargetingService.saveNewsTarget(...)`; with no targets → falls back to the activity-stream post (`postNews`). `publish_news_in_activity_stream` kept as an alias.
- **`schedule_news(news_id, publish_date, targets?)`** (write) — validates the ISO date, sets `schedulePostDate` + `STAGED`, calls `NewsService.scheduleNews(..., ARTICLE)`; optionally stages targets.
- **`unpublish_news(news_id)`** (write) — `NewsService.unpublishNews(newsId, publisher, false)`.

## Verified
- `list_news_targets` **verified live via EVA** (returns empty on an instance with no targets configured — correct).
- Write tools: **37 mock-based tests green** (targets `can_publish`, publish→saveNewsTarget, empty-targets→stream fallback, schedule sets date/state + service call, unpublish, permission-denied cases). `mvn install -pl content-service -am` BUILD SUCCESS.

## ⚠️ Open question for review — `publish_news` with no targets
Code distinction found while building: **posting to the activity stream** (`postNews` → `POSTED` state) and **publishing** (`NewsService.publishNews` → sets `published=true`, widens permissions, notifies, and assigns targets only `if getTargets() != null`) are **two different operations**. This tool's empty-targets path currently does the *activity-stream post* (`postNews`). A "publish with no targets" arguably should call `publishNews` (set `published=true`) instead of — or in addition to — the post. **Please advise the intended semantics**; happy to adjust (also the `displayed` default and whether `publish_news` should re-post an already-posted article).

## CI
Depends on **mcp-server #13** via #807 (the `UploadToolUtils` SNAPSHOT) — CI red until #13 releases, same as the rest of the content stack.

Board: EXO-88370.

🤖 Generated with [Claude Code](https://claude.com/claude-code)