### PR TITLE
feat: display article category in Headlines news list - EXO-88132 - eXIP7.3.0.1

### DIFF
--- a/content-service/src/main/java/io/meeds/content/news/service/NewsService.java
+++ b/content-service/src/main/java/io/meeds/content/news/service/NewsService.java
@@ -699,6 +699,16 @@ public class NewsService {
       news.setCanPublish(NewsUtils.canPublishNews(news.getSpaceId(), currentIdentity));
       news.setCanRefer(canReferToNote(news, currentIdentity));
       news.setCanSchedule(canScheduleNews(news.getSpaceId(), currentIdentity, news));
+      if (StringUtils.isNotBlank(news.getActivityId())) {
+        try {
+          ExoSocialActivity activity = activityManager.getActivity(news.getActivityId());
+          if (activity != null) {
+            news.setCategories(activity.getCategoryIds());
+          }
+        } catch (Exception e) {
+          LOG.debug("Error getting activity of News with id {}", news.getActivityId(), e);
+        }
+      }
     });
     return newsList;
   }

--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsLatestViewItem.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsLatestViewItem.vue
@@ -81,10 +81,24 @@
           'ps-3 d-flex flex-column': index === 0 && isMobile
         }"
         class="articleInfos no-min-width full-width background-transparent">
-        <div v-if="showArticleDate" class="postDate text-subtitle line-height-1 flex-column mb-1 mt-0 my-auto">
-          <date-format
-            :value="displayDate"
-            :format="dateFormat" />
+        <div
+          v-if="firstCategory && index === 0"
+          class="position-absolute t-0 r-0 mt-n5 me-2 mb-2 white rounded-pill">
+          <category-chip
+            :category="firstCategory"
+            small />
+        </div>
+        <div class="d-flex align-center mb-1">
+          <div v-if="showArticleDate" class="postDate text-subtitle line-height-1 flex-column mt-0 my-auto">
+            <date-format
+              :value="displayDate"
+              :format="dateFormat" />
+          </div>
+          <v-spacer v-if="firstCategory && index > 0" />
+          <category-chip
+            v-if="firstCategory && index > 0"
+            :category="firstCategory"
+            small />
         </div>
         <span
           v-if="showArticleTitle"
@@ -182,8 +196,12 @@ export default {
     showArticleSpace: true,
     showArticleDate: true,
     showArticleReactions: true,
+    firstCategory: null,
   }),
   computed: {
+    firstCategoryId() {
+      return this.item?.categories?.[0];
+    },
     hasSummary() {
       return !!this.item?.properties?.summary;
     },
@@ -217,6 +235,20 @@ export default {
     articleUrl() {
       return eXo.env.portal.userName !== '' ? this.item.url : `${eXo.env.portal.context}/${eXo.env.portal.portalName}/news-detail?newsId=${this.item.id}&type=article`;
     }
+  },
+  watch: {
+    firstCategoryId: {
+      immediate: true,
+      handler() {
+        if (this.firstCategoryId) {
+          this.$categoryService.getCategory(this.firstCategoryId)
+            .then(category => this.firstCategory = category)
+            .catch(() => this.firstCategory = null);
+        } else {
+          this.firstCategory = null;
+        }
+      },
+    },
   },
   created() {
     this.reset();


### PR DESCRIPTION
Propagate the linked activity's categories into News DTOs returned by NewsService#getNews() so list views have category data available. Show the first category in the Headlines template