### PR TITLE
feat: display article category in List, Card, Carousel and Mosaic news blocks - EXO-88133 - eXIP7.3.0.1

### DIFF
--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsCardsViewItem.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsCardsViewItem.vue
@@ -50,6 +50,13 @@
         type="content-card-event-date-chip"
         element="span"
         class="mt-n12" />
+      <div
+        v-if="firstCategory"
+        class="position-absolute b-0 r-0 ma-2 white rounded-pill">
+        <category-chip
+          :category="firstCategory"
+          small />
+      </div>
     </v-sheet>
     <div
       class="text-area articleLinkDetails"
@@ -109,6 +116,13 @@
               element="span"
               class="mt-2 mb-2" />
             <div
+              v-if="firstCategory"
+              class="d-flex justify-end mt-2 mb-2">
+              <category-chip
+                :category="firstCategory"
+                small />
+            </div>
+            <div
               v-if="showArticleSummary && hasSummary"
               class="text-truncate-3 mt-4 text-subtitle">
               {{ item?.properties?.summary }}
@@ -160,9 +174,27 @@ export default {
     slideActive: false,
     isArticleLinkFocused: false,
     isCardFocused: false,
-    showDetails: false
+    showDetails: false,
+    firstCategory: null
   }),
+  watch: {
+    firstCategoryId: {
+      immediate: true,
+      handler() {
+        if (this.firstCategoryId) {
+          this.$categoryService.getCategory(this.firstCategoryId)
+            .then(category => this.firstCategory = category)
+            .catch(() => this.firstCategory = null);
+        } else {
+          this.firstCategory = null;
+        }
+      },
+    },
+  },
   computed: {
+    firstCategoryId() {
+      return this.item?.categories?.[0];
+    },
     hasSummary() {
       return this.item?.properties?.summary?.length;
     },

--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsListTemplateViewItem.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsListTemplateViewItem.vue
@@ -49,10 +49,15 @@
       </div>
       <div
         class="article-item-content d-flex flex-column align-stretch flex-grow-1 no-min-width ms-0 px-2">
-        <div v-if="showArticleDate" class="text-subtitle mb-1">
+        <div v-if="showArticleDate" class="d-flex align-center text-subtitle mb-1">
           <date-format
             :value="displayDate"
             :format="dateFormat" />
+          <v-spacer v-if="firstCategory" />
+          <category-chip
+            v-if="firstCategory"
+            :category="firstCategory"
+            small />
         </div>
         <span
           v-if="showArticleTitle"
@@ -117,8 +122,26 @@ export default {
       month: 'long',
       day: 'numeric',
     },
+    firstCategory: null,
   }),
+  watch: {
+    firstCategoryId: {
+      immediate: true,
+      handler() {
+        if (this.firstCategoryId) {
+          this.$categoryService.getCategory(this.firstCategoryId)
+            .then(category => this.firstCategory = category)
+            .catch(() => this.firstCategory = null);
+        } else {
+          this.firstCategory = null;
+        }
+      },
+    },
+  },
   computed: {
+    firstCategoryId() {
+      return this.item?.categories?.[0];
+    },
     hasSummary() {
       return !!this.item?.properties?.summary;
     },

--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsMosaicTemplateViewItem.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsMosaicTemplateViewItem.vue
@@ -59,12 +59,20 @@
         </v-img>
         <div
           class="article-item-content position-absolute mb-1 b-0 full-width d-flex flex-column align-stretch flex-grow-1 no-min-width ms-0 px-2">
-          <div 
+          <div
             v-if="showArticleDate && !(index && isSmallWidth)"
-            class="text-subtitle mt-1 line-height-normal mb-1">
+            class="d-flex align-center text-subtitle mt-1 line-height-normal mb-1">
             <date-format
               :value="displayDate"
               :format="dateFormat" />
+            <v-spacer v-if="firstCategory" />
+            <div
+              v-if="firstCategory"
+              class="white rounded-pill mt-n6">
+              <category-chip
+                :category="firstCategory"
+                small />
+            </div>
           </div>
           <span
             v-if="showArticleTitle"
@@ -170,9 +178,27 @@ export default {
         month: 'long',
         day: 'numeric',
       },
+      firstCategory: null,
     };
   },
+  watch: {
+    firstCategoryId: {
+      immediate: true,
+      handler() {
+        if (this.firstCategoryId) {
+          this.$categoryService.getCategory(this.firstCategoryId)
+            .then(category => this.firstCategory = category)
+            .catch(() => this.firstCategory = null);
+        } else {
+          this.firstCategory = null;
+        }
+      },
+    },
+  },
   computed: {
+    firstCategoryId() {
+      return this.item?.categories?.[0];
+    },
     articleUrl() {
       return eXo.env.portal.userName !== ''
         ? this.item.url

--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsSliderView.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsSliderView.vue
@@ -55,6 +55,13 @@
               type="content-card-event-date-chip"
               element="span"
               class="position-absolute b-0 line-height-normal" />
+            <div
+              v-if="firstCategory(item)"
+              class="position-absolute b-0 r-0 ma-2 white rounded-pill">
+              <category-chip
+                :category="firstCategory(item)"
+                small />
+            </div>
             <div class="px-10 mt-auto pb-13 no-min-width full-width flex-column">
               <div
                 :class="$vuetify.rtl && 'l-0' || 'r-0'"
@@ -101,6 +108,9 @@ export default {
       }
     },
   },
+  data: () => ({
+    firstCategories: {},
+  }),
   computed: {
     news(){
       return this.newsList && this.newsList.filter(news => !!news);
@@ -120,9 +130,30 @@ export default {
       return this.selectedOption.showArticleSummary;
     },
   },
+  watch: {
+    news: {
+      immediate: true,
+      handler() {
+        this.refreshCategories();
+      },
+    },
+  },
   methods: {
     openDrawer() {
       this.$root.$emit('news-settings-drawer-open');
+    },
+    refreshCategories() {
+      (this.news || []).forEach(item => {
+        const categoryId = item?.categories?.[0];
+        if (categoryId && !this.firstCategories[item.id]) {
+          this.$categoryService.getCategory(categoryId)
+            .then(category => this.firstCategories = {...this.firstCategories, [item.id]: category})
+            .catch(() => null);
+        }
+      });
+    },
+    firstCategory(item) {
+      return this.firstCategories[item.id];
     },
   }
 };


### PR DESCRIPTION
Show the first category of an article, styled like the category-chip on the detail page, across the remaining news list display modes