### PR TITLE
feat: let a News article supply its content preview when browsing by category - EXO-88138 - eXIP7.3.0.1

### DIFF
--- a/content-service/src/main/java/io/meeds/content/news/plugin/NewsCategoryPlugin.java
+++ b/content-service/src/main/java/io/meeds/content/news/plugin/NewsCategoryPlugin.java
@@ -1,0 +1,93 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.content.news.plugin;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import org.exoplatform.container.PortalContainer;
+
+import io.meeds.content.news.model.News;
+import io.meeds.content.news.service.NewsService;
+import io.meeds.social.category.model.CategoryEntryItem;
+import io.meeds.social.category.plugin.CategoryPlugin;
+import io.meeds.social.category.service.CategoryPluginService;
+
+import jakarta.annotation.PostConstruct;
+
+@Component
+public class NewsCategoryPlugin implements CategoryPlugin {
+
+  private static final String ICON = "fa-newspaper";
+
+  public static final String  OBJECT_TYPE = NewsPermanentLinkPlugin.OBJECT_TYPE;
+
+  @Autowired
+  private PortalContainer      container;
+
+  @Autowired
+  private NewsService          newsService;
+
+  @PostConstruct
+  public void init() {
+    container.getComponentInstanceOfType(CategoryPluginService.class).addPlugin(this);
+  }
+
+  @Override
+  public String getType() {
+    return OBJECT_TYPE;
+  }
+
+  @Override
+  public boolean canAccess(String objectId, String username) {
+    News news = newsService.getNewsArticleById(objectId);
+    return news != null && newsService.canViewNews(news, username);
+  }
+
+  @Override
+  public boolean canEdit(String objectId, String username) {
+    News news = newsService.getNewsArticleById(objectId);
+    return news != null && newsService.canEditNews(news, username);
+  }
+
+  @Override
+  public CategoryEntryItem getEntryItem(String objectId, String username) {
+    News news = newsService.getNewsArticleById(objectId);
+    if (news == null) {
+      return null;
+    }
+    return new CategoryEntryItem(news.getId(),
+                                   OBJECT_TYPE,
+                                   ICON,
+                                   news.getTitle(),
+                                   news.getProperties() == null ? null : news.getProperties().getSummary(),
+                                   news.getIllustrationURL(),
+                                   news.getUrl(),
+                                   news.getAuthorDisplayName(),
+                                   news.getAuthorAvatarUrl(),
+                                   news.getSpaceDisplayName(),
+                                   news.getSpaceAvatarUrl(),
+                                   news.getUpdateDate(),
+                                   news.getLikesCount(),
+                                   news.getCommentsCount(),
+                                   news.getViewsCount() == null ? 0 : news.getViewsCount(),
+                                   news.getCategories());
+  }
+
+}

--- a/content-webapp/src/main/webapp/vue-app/news-details/components/ExoNewsDetailsToolBar.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-details/components/ExoNewsDetailsToolBar.vue
@@ -100,7 +100,8 @@
         :key="category.id"
         :category="category"
         chip-class="me-2"
-        small />
+        small
+        @select="openEntryListDrawer" />
       <v-btn
         v-if="remainingCategoriesCount > 0"
         :title="$t('categories.remainingCount', {0: remainingCategoriesCount})"
@@ -116,7 +117,9 @@
     </div>
     <categories-list-drawer
       v-if="categoriesListDrawerOpened"
-      ref="categoriesListDrawer" />
+      ref="categoriesListDrawer"
+      @select="openEntryListDrawer" />
+    <category-entry-drawer ref="entryListDrawer" />
   </div>
 </template>
 
@@ -248,6 +251,9 @@ export default {
       this.categoriesListDrawerOpened = true;
       await this.$nextTick();
       this.$refs.categoriesListDrawer.open(this.categories);
+    },
+    openEntryListDrawer(category) {
+      this.$refs.entryListDrawer.open(category.id, ['news', 'notes']);
     },
     goBack() {
       if (this.lastVisitedPage) {

--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsCardsViewItem.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsCardsViewItem.vue
@@ -55,6 +55,7 @@
         class="position-absolute b-0 r-0 ma-2 white rounded-pill">
         <category-chip
           :category="firstCategory"
+          tabindex="-1"
           small />
       </div>
     </v-sheet>
@@ -120,6 +121,7 @@
               class="d-flex justify-end mt-2 mb-2">
               <category-chip
                 :category="firstCategory"
+                tabindex="-1"
                 small />
             </div>
             <div

--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsLatestViewItem.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsLatestViewItem.vue
@@ -86,6 +86,7 @@
           class="position-absolute t-0 r-0 mt-n5 me-2 mb-2 white rounded-pill">
           <category-chip
             :category="firstCategory"
+            tabindex="-1"
             small />
         </div>
         <div class="d-flex align-center mb-1">

--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsListTemplateViewItem.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsListTemplateViewItem.vue
@@ -57,6 +57,7 @@
           <category-chip
             v-if="firstCategory"
             :category="firstCategory"
+            tabindex="-1"
             small />
         </div>
         <span

--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsMosaicTemplateViewItem.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsMosaicTemplateViewItem.vue
@@ -71,6 +71,7 @@
               class="white rounded-pill mt-n6">
               <category-chip
                 :category="firstCategory"
+                tabindex="-1"
                 small />
             </div>
           </div>

--- a/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsSliderView.vue
+++ b/content-webapp/src/main/webapp/vue-app/news-list-view/components/views/NewsSliderView.vue
@@ -60,6 +60,7 @@
               class="position-absolute b-0 r-0 ma-2 white rounded-pill">
               <category-chip
                 :category="firstCategory(item)"
+                tabindex="-1"
                 small />
             </div>
             <div class="px-10 mt-auto pb-13 no-min-width full-width flex-column">


### PR DESCRIPTION
Add NewsCategoryPlugin, registering News under the CategoryPlugin SPI so articles resolve into a generic content preview (title, summary, illustration, author, date, url, icon) for the new "browse content by category" drawer in social. Wire the category chip on the article toolbar to open that drawer for the selected category.