### PR TITLE
fix: Exclude unposted articles/notes from the 'List any articles published' news target -EXO-88323

### DIFF
--- a/content-service/src/main/java/io/meeds/content/news/service/NewsService.java
+++ b/content-service/src/main/java/io/meeds/content/news/service/NewsService.java
@@ -1860,10 +1860,17 @@ public class NewsService {
     metadataFilter.setMetadataName(NEWS_METADATA_NAME);
     metadataFilter.setMetadataTypeName(NEWS_METADATA_TYPE.getName());
     metadataFilter.setMetadataObjectTypes(List.of(NEWS_METADATA_PAGE_OBJECT_TYPE));
-    metadataFilter.setMetadataProperties(Map.of(NEWS_PUBLICATION_STATE, POSTED, NEWS_DELETED, "false"));
+    metadataFilter.setMetadataProperties(Map.of(NEWS_ACTIVITY_POSTED,
+                                                "true",
+                                                NEWS_PUBLICATION_STATE,
+                                                POSTED,
+                                                NEWS_DELETED,
+                                                "false"));
     metadataFilter.setMetadataSpaceIds(NewsUtils.getMyFilteredSpacesIds(currentIdentity, filter.getSpaces()));
     metadataFilter.setSortField(filter.getSortField());
-    metadataFilter.setCombinedMetadataProperties(Map.of(PUBLISHED,
+    metadataFilter.setCombinedMetadataProperties(Map.of(NEWS_ACTIVITY_POSTED,
+                                                        "true",
+                                                        PUBLISHED,
                                                         "true",
                                                         NEWS_AUDIENCE,
                                                         NewsUtils.ALL_NEWS_AUDIENCE,
@@ -1923,10 +1930,17 @@ public class NewsService {
     metadataFilter.setMetadataTypeName(NEWS_METADATA_TYPE.getName());
     metadataFilter.setMetadataObjectTypes(List.of(NEWS_METADATA_PAGE_OBJECT_TYPE));
     metadataFilter.setCreatorId(Long.parseLong(identityManager.getOrCreateUserIdentity(filter.getAuthor()).getId()));
-    metadataFilter.setMetadataProperties(Map.of(NEWS_PUBLICATION_STATE, POSTED, NEWS_DELETED, "false"));
+    metadataFilter.setMetadataProperties(Map.of(NEWS_ACTIVITY_POSTED,
+                                                "true",
+                                                NEWS_PUBLICATION_STATE,
+                                                POSTED,
+                                                NEWS_DELETED,
+                                                "false"));
     metadataFilter.setMetadataSpaceIds(NewsUtils.getMyFilteredSpacesIds(currentIdentity, filter.getSpaces()));
     metadataFilter.setSortField(filter.getSortField());
-    metadataFilter.setCombinedMetadataProperties(Map.of(PUBLISHED,
+    metadataFilter.setCombinedMetadataProperties(Map.of(NEWS_ACTIVITY_POSTED,
+                                                        "true",
+                                                        PUBLISHED,
                                                         "true",
                                                         NEWS_AUDIENCE,
                                                         NewsUtils.ALL_NEWS_AUDIENCE,


### PR DESCRIPTION
Prior to this change, an article or note whose posting was disabled kept showing up in a space's News List View widget when configured with "List any articles published" as its source.
This change filters that listing on the activityPosted flag, which is the one actually reset when posting is disabled, so unposted content is correctly excluded going forward.

(cherry picked from commit 1b43e090bbc31435e8d8d29a30b737352dab1b98)