### PR TITLE
fix: persist the activity id on the note page when publishing it as a news article - EXO-88497 - eXIP7.3.0.1

### DIFF
--- a/content-service/src/main/java/io/meeds/content/news/service/NewsService.java
+++ b/content-service/src/main/java/io/meeds/content/news/service/NewsService.java
@@ -2216,6 +2216,13 @@ public class NewsService {
     if (activityId != null && !StringUtils.isEmpty(news.getId())) {
       Page newsPage = noteService.getNoteById(news.getId());
       if (newsPage != null) {
+        if (!activityId.equals(newsPage.getActivityId())) {
+          // Persist the activity id on the underlying page so that later lookups
+          // (e.g. category resolution) can resolve the news metadata object type
+          // instead of falling back to the plain note object type.
+          newsPage.setActivityId(activityId);
+          noteService.updateNote(newsPage);
+        }
         NewsPageObject newsPageObject = new NewsPageObject(NEWS_METADATA_PAGE_OBJECT_TYPE,
                                                            newsPage.getId(),
                                                            null,


### PR DESCRIPTION
postNewsActivity creates the activity for a newly published article and links its categories, but never persisted the resulting activity id back onto the underlying note page (only set in-memory on the News DTO). On any later request - e.g. opening "Manage Categories" from the note's action menu - the reloaded page had a blank activityId, so NoteCategoryPlugin.toCategoryObject took the direct "notes"+pageId branch instead of resolving through the activity to where the categories are actually linked, and always returned no categories.