### PR TITLE
fix: News drafts listing issue - EXO-88464

### DIFF
--- a/content-service/src/main/java/io/meeds/content/news/service/NewsService.java
+++ b/content-service/src/main/java/io/meeds/content/news/service/NewsService.java
@@ -1969,35 +1969,43 @@ public class NewsService {
     metadataFilter.setSortField(filter.getSortField());
     metadataFilter.setMetadataObjectTypes(List.of(NEWS_METADATA_DRAFT_OBJECT_TYPE, NEWS_METADATA_LATEST_DRAFT_OBJECT_TYPE));
     metadataFilter.setMetadataSpaceIds(NewsUtils.getMyFilteredSpacesIds(currentIdentity, filter.getSpaces()));
-    return metadataService.getMetadataItemsByFilter(metadataFilter, filter.getOffset(), filter.getLimit())
-                          .stream()
-                          .map(draftArticle -> {
-                            try {
-                              News draft = buildDraftArticle(draftArticle.getObjectId(), currentIdentity);
-                              if (draft != null && draftArticle.getParentObjectId() != null) {
-                                News parentArticle = buildArticle(draftArticle.getParentObjectId(),
-                                                                  currentIdentity,
-                                                                  draft.getLang(),
-                                                                  true);
-                                draft.setReferred(parentArticle.isReferred());
-                                draft.setFromExternalPage(parentArticle.isFromExternalPage());
-                                draft.setOwner(parentArticle.getOwner());
-                              }
-                              return draft;
-                            } catch (IllegalAccessException e) {
-                              return null;
-                            } catch (Exception e) {
-                              LOG.error("Error while building new draft article", e);
-                              return null;
-                            }
-                          })
-                          .filter(article -> {
-                            if (article != null) {
-                              return canEditNews(article, currentIdentity.getUserId());
-                            }
-                            return false;
-                          })
-                          .toList();
+
+    int limit = filter.getLimit();
+    int offset = filter.getOffset();
+    List<News> drafts = new ArrayList<>();
+    int fetchedCount;
+    do {
+      List<MetadataItem> metadataItems = metadataService.getMetadataItemsByFilter(metadataFilter, offset, limit);
+      fetchedCount = metadataItems.size();
+      offset += fetchedCount;
+      metadataItems.stream()
+                    .map(draftArticle -> buildDraftArticleOrNull(draftArticle, currentIdentity))
+                    .filter(article -> article != null && canEditNews(article, currentIdentity.getUserId()))
+                    .forEach(drafts::add);
+    } while (limit > 0 && drafts.size() < limit && fetchedCount == limit);
+
+    return limit > 0 && drafts.size() > limit ? drafts.subList(0, limit) : drafts;
+  }
+
+  private News buildDraftArticleOrNull(MetadataItem draftArticle, Identity currentIdentity) {
+    try {
+      News draft = buildDraftArticle(draftArticle.getObjectId(), currentIdentity);
+      if (draft != null && draftArticle.getParentObjectId() != null) {
+        News parentArticle = buildArticle(draftArticle.getParentObjectId(),
+                                          currentIdentity,
+                                          draft.getLang(),
+                                          true);
+        draft.setReferred(parentArticle.isReferred());
+        draft.setFromExternalPage(parentArticle.isFromExternalPage());
+        draft.setOwner(parentArticle.getOwner());
+      }
+      return draft;
+    } catch (IllegalAccessException e) {
+      return null;
+    } catch (Exception e) {
+      LOG.error("Error while building new draft article", e);
+      return null;
+    }
   }
 
   private boolean isArticleOwner(News article, String userName) {

--- a/content-service/src/test/java/io/meeds/content/news/service/NewsServiceTest.java
+++ b/content-service/src/test/java/io/meeds/content/news/service/NewsServiceTest.java
@@ -528,6 +528,69 @@ public class NewsServiceTest {
   }
 
   @Test
+  public void testGetDraftArticlesWithOrphanedMetadata() throws Exception {
+
+    // Given
+    DraftPage draftPage1 = new DraftPage();
+    draftPage1.setContent("draft body 1");
+    draftPage1.setTitle("draft article 1");
+    draftPage1.setId("1");
+    draftPage1.setOwner("john");
+    draftPage1.setWikiOwner("/space/groupId");
+
+    DraftPage draftPage2 = new DraftPage();
+    draftPage2.setContent("draft body 2");
+    draftPage2.setTitle("draft article 2");
+    draftPage2.setId("2");
+    draftPage2.setOwner("john");
+    draftPage2.setWikiOwner("/space/groupId");
+
+    when(noteService.getDraftNoteById(eq("1"), anyString())).thenReturn(draftPage1);
+    when(noteService.getDraftNoteById(eq("2"), anyString())).thenReturn(draftPage2);
+    // "orphan" simulates a metadata row whose underlying draft note was deleted
+    // without cleaning up its metadata item
+    when(noteService.getDraftNoteById(eq("orphan"), anyString())).thenReturn(null);
+
+    Map<String, String> properties = new HashMap<>();
+    MetadataItem orphanMetadataItem = mock(MetadataItem.class);
+    when(orphanMetadataItem.getObjectId()).thenReturn("orphan");
+    when(orphanMetadataItem.getProperties()).thenReturn(properties);
+    MetadataItem metadataItem1 = mock(MetadataItem.class);
+    when(metadataItem1.getObjectId()).thenReturn("1");
+    when(metadataItem1.getProperties()).thenReturn(properties);
+    MetadataItem metadataItem2 = mock(MetadataItem.class);
+    when(metadataItem2.getObjectId()).thenReturn("2");
+    when(metadataItem2.getProperties()).thenReturn(properties);
+
+    when(metadataService.getMetadataItemsByMetadataAndObject(any(MetadataKey.class),
+                                                             any(MetadataObject.class))).thenReturn(List.of(metadataItem1));
+    Identity identity = mock(Identity.class);
+    when(identity.getUserId()).thenReturn("john");
+    Space space1 = mockSpace();
+    List<Space> myFilteredSpaces = Arrays.asList(space1);
+    NEWS_UTILS.when(() -> NewsUtils.getMyFilteredSpacesIds(identity, new ArrayList<>())).thenReturn(myFilteredSpaces);
+    // First page (offset=0, limit=2) returns the orphan alongside one real draft,
+    // so only 1 real draft is resolved out of a full page of 2 metadata rows.
+    when(metadataService.getMetadataItemsByFilter(any(), eq(0L), eq(2L)))
+                                                                          .thenReturn(List.of(orphanMetadataItem, metadataItem1));
+    // Second page (offset=2, limit=2) returns the remaining real draft.
+    when(metadataService.getMetadataItemsByFilter(any(), eq(2L), eq(2L))).thenReturn(List.of(metadataItem2));
+    when(spaceService.canRedactOnSpace(any(Space.class), any(Identity.class))).thenReturn(true);
+    NEWS_UTILS.when(() -> NewsUtils.getUserIdentity(anyString())).thenReturn(identity);
+
+    // When
+    NewsFilter newsFilter = new NewsFilter();
+    newsFilter.setDraftNews(true);
+    newsFilter.setOffset(0);
+    newsFilter.setLimit(2);
+    List<News> newsList = newsService.getNews(newsFilter, identity);
+
+    // Then
+    assertNotNull(newsList);
+    assertEquals(newsList.size(), 2);
+  }
+
+  @Test
   public void testPostNews() throws Exception {
 
     // Given


### PR DESCRIPTION
Before this change, when a news draft's underlying note was deleted without cleaning up its metadata row, the orphaned metadata item still consumed a slot in the paginated drafts query before being dropped as unresolvable, so the drafts listing could return fewer items than the requested limit even though more real drafts existed, making the Show more button disappear prematurely. To fix this problem, NewsService.buildDraftArticles now keeps fetching additional pages of metadata items until it has gathered as many resolved drafts as requested by the limit, or there are no more metadata rows left. After this change, orphaned metadata rows no longer cause real drafts to be silently skipped, and the Show more button behaves correctly based on the actual number of existing drafts.